### PR TITLE
Refactor buster-cli model structures and update YAML templates

### DIFF
--- a/packages/buster-cli/src/assets/templates/buster_model.yml
+++ b/packages/buster-cli/src/assets/templates/buster_model.yml
@@ -1,6 +1,6 @@
 version: 2
 
-semantic_models:
+models:
   - name: the_name_of_the_semantic_model ## Required
     description: same as always ## Optional
     model: ref('some_model') ## Required: the database identifier of the table/view/mv that this semantic model relates to.

--- a/packages/buster-cli/src/utils/buster/types.rs
+++ b/packages/buster-cli/src/utils/buster/types.rs
@@ -47,7 +47,7 @@ pub struct PostDatasetsColumnsRequest {
 #[derive(Debug, Serialize)]
 pub struct PostDatasetsEntityRelationshipsRequest {
     pub name: String,
-    pub expr: Vec<String>,
+    pub expr: String,
     #[serde(rename = "type")]
     pub type_: String,
 }

--- a/packages/buster-cli/src/utils/file/model_files.rs
+++ b/packages/buster-cli/src/utils/file/model_files.rs
@@ -22,23 +22,17 @@ pub struct BusterModelObject {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BusterModel {
     pub version: i32,
-    pub semantic_models: Vec<SemanticModel>,
+    pub models: Vec<Model>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct SemanticModel {
+pub struct Model {
     pub name: String,
-    pub defaults: ModelDefaults,
     pub description: String,
     pub model: Option<String>,
     pub entities: Vec<Entity>,
     pub dimensions: Vec<Dimension>,
     pub measures: Vec<Measure>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ModelDefaults {
-    pub agg_time_dimension: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -121,7 +115,7 @@ pub async fn upload_model_files(
 
     // Iterate through each model object and the semantic models within. These are the datasets we want to create.
     for model in model_objects {
-        for semantic_model in model.model_file.semantic_models {
+        for semantic_model in model.model_file.models {
             let mut columns = Vec::new();
 
             for column in semantic_model.dimensions {
@@ -151,7 +145,7 @@ pub async fn upload_model_files(
             for entity in semantic_model.entities {
                 entity_relationships.push(PostDatasetsEntityRelationshipsRequest {
                     name: entity.name,
-                    expr: vec![entity.expr],
+                    expr: entity.expr,
                     type_: entity.entity_type,
                 });
             }

--- a/packages/buster-cli/tests/command_tests.rs
+++ b/packages/buster-cli/tests/command_tests.rs
@@ -2,7 +2,7 @@
 fn test_convert_buster_to_dbt_model() {
     let buster_yaml = r#"
 version: 2
-semantic_models:
+models:
   - name: test_model
     aliases: ["alias1"]
     entities:
@@ -23,7 +23,7 @@ semantic_models:
 "#;
 
     let dbt_yaml = convert_buster_to_dbt_model(buster_yaml).unwrap();
-    
+
     // The converted YAML shouldn't contain Buster-specific fields
     assert!(!dbt_yaml.contains("aliases"));
     assert!(!dbt_yaml.contains("join_type"));


### PR DESCRIPTION
- Renamed `semantic_models` to `models` in YAML template and related structures for consistency.
- Changed `expr` field type in `PostDatasetsEntityRelationshipsRequest` from `Vec<String>` to `String` to simplify data handling.
- Updated `BusterModel` struct to reflect the new `models` naming and removed unused `ModelDefaults` struct.
- Adjusted tests to align with the updated model structure.

These changes enhance clarity and maintainability in the model representation and data handling within the buster-cli.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `buster-cli` model structures by renaming `semantic_models` to `models` and updating related fields and tests.
> 
>   - **Model Structure**:
>     - Renamed `semantic_models` to `models` in `buster_model.yml` and `BusterModel` struct.
>     - Removed `ModelDefaults` struct from `model_files.rs`.
>   - **Field Type Change**:
>     - Changed `expr` field type from `Vec<String>` to `String` in `PostDatasetsEntityRelationshipsRequest` in `types.rs`.
>   - **Tests**:
>     - Updated tests in `command_tests.rs` to align with new model structure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=buster-so%2Fbuster&utm_source=github&utm_medium=referral)<sup> for 1cff6c01e42a628145e95614e1bc33bdcbf0d568. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->