### PR TITLE
Refactor permission handling in get_message_with_permission function

### DIFF
--- a/api/src/routes/ws/threads_and_messages/messages_utils.rs
+++ b/api/src/routes/ws/threads_and_messages/messages_utils.rs
@@ -84,7 +84,9 @@ pub async fn get_message_with_permission(
         }
     };
 
-    let final_permission = if permission.is_none() && !is_public_thread {
+    let final_permission = if permission.is_some() {
+        permission.unwrap()
+    } else if !is_public_thread {
         return Err(anyhow!("No message found with permissions"));
     } else {
         AssetPermissionRole::Viewer


### PR DESCRIPTION
- Updated the logic to determine final_permission by checking if permission is Some, simplifying the condition.
- Improved error handling for non-public threads when no permissions are provided.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `get_message_with_permission` to simplify permission logic and improve error handling for non-public threads.
> 
>   - **Refactor**:
>     - Simplified `final_permission` logic in `get_message_with_permission()` by checking if `permission` is `Some` and using `unwrap()`.
>   - **Error Handling**:
>     - Improved error handling for non-public threads when no permissions are provided in `get_message_with_permission()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=buster-so%2Fbuster&utm_source=github&utm_medium=referral)<sup> for a7ae1b1dfd51b6067df7a6a8743bac7325fc083a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->