### PR TITLE
add DATABASE_URL export to Makefile

### DIFF
--- a/api/makefile
+++ b/api/makefile
@@ -4,6 +4,7 @@ dev:
 	ollama serve &
 	ollama pull mxbai-embed-large
 	supabase db reset 
+	export DATABASE_URL=postgres://postgres:postgres@127.0.0.1:54322/postgres && \
 	diesel migration run && \
 	PGPASSWORD=postgres psql -h 127.0.0.1 -p 54322 -d postgres -U postgres -f src/database/seed.sql && \
 	export RUST_LOG=debug


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `DATABASE_URL` export to `makefile` for database connection in `dev` target.
> 
>   - **Makefile Changes**:
>     - Added `export DATABASE_URL=postgres://postgres:postgres@127.0.0.1:54322/postgres` to the `dev` target in `makefile` to set the database connection string before running migrations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=buster-so%2Fbuster&utm_source=github&utm_medium=referral)<sup> for fba7cc9c8e835b15bb9d020d4a862a1d67af7dcf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->