### PR TITLE
refetch after user default access changed

### DIFF
--- a/web/src/app/app/settings/users/[userId]/_overview/UserDefaultAccess.tsx
+++ b/web/src/app/app/settings/users/[userId]/_overview/UserDefaultAccess.tsx
@@ -4,14 +4,16 @@ import { Text, Title } from '@/components/text';
 import { Card, Select } from 'antd';
 import { useMemoizedFn } from 'ahooks';
 
-export const UserDefaultAccess: React.FC<{ user: OrganizationUser; isAdmin: boolean }> = ({
-  user,
-  isAdmin
-}) => {
+export const UserDefaultAccess: React.FC<{
+  user: OrganizationUser;
+  isAdmin: boolean;
+  refetchUser: () => void;
+}> = ({ user, isAdmin, refetchUser }) => {
   const { mutateAsync, isPending } = useUpdateUser();
 
-  const onChange = useMemoizedFn((value: string) => {
-    mutateAsync({ userId: user.id, role: value as OrganizationUser['role'] });
+  const onChange = useMemoizedFn(async (value: string) => {
+    await mutateAsync({ userId: user.id, role: value as OrganizationUser['role'] });
+    refetchUser();
   });
 
   return (

--- a/web/src/app/app/settings/users/[userId]/_overview/UserOverviewController.tsx
+++ b/web/src/app/app/settings/users/[userId]/_overview/UserOverviewController.tsx
@@ -8,14 +8,14 @@ import { UserLineageHeader } from './UserLineageHeader';
 import { UserDatasetSearch } from './UserDatasetSearch';
 
 export const UserOverviewController = React.memo(({ userId }: { userId: string }) => {
-  const { data: user } = useGetUser({ userId });
+  const { data: user, refetch: refetchUser } = useGetUser({ userId });
   const isAdmin = useUserConfigContextSelector((x) => x.isAdmin);
 
   if (!user) return null;
 
   return (
     <>
-      <UserDefaultAccess user={user} isAdmin={isAdmin} />
+      <UserDefaultAccess user={user} isAdmin={isAdmin} refetchUser={refetchUser} />
       <UserLineageHeader className="!mt-[48px]" user={user} />
       <UserDatasetSearch user={user} />
     </>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `UserDefaultAccess` now refetches user data after role change to update UI.
> 
>   - **Behavior**:
>     - `UserDefaultAccess` component now calls `refetchUser` after updating user role to ensure UI reflects changes.
>   - **Components**:
>     - `UserDefaultAccess` in `UserDefaultAccess.tsx` updated to accept `refetchUser` prop and call it after `mutateAsync`.
>     - `UserOverviewController` in `UserOverviewController.tsx` updated to pass `refetchUser` to `UserDefaultAccess`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=buster-so%2Fbuster&utm_source=github&utm_medium=referral)<sup> for 00a6f1a8319177b9c52cb526854345d1654b0f14. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->