### PR TITLE
fix permission check on post_dataset rest

### DIFF
--- a/api/migrations/2025-01-17-182615_user_info_cache/up.sql
+++ b/api/migrations/2025-01-17-182615_user_info_cache/up.sql
@@ -23,7 +23,7 @@ CREATE TRIGGER sync_user_org_attributes
     EXECUTE FUNCTION update_user_org_attributes();
 
     -- Update existing records
-    UPDATE users u
+    UPDATE public.users u
     SET attributes = jsonb_set(
         jsonb_set(
             COALESCE(attributes, '{}'::jsonb),

--- a/api/src/database/seed.sql
+++ b/api/src/database/seed.sql
@@ -982,25 +982,25 @@ INSERT INTO public.terms (id, name, definition, sql_snippet, organization_id, cr
 --
 
 INSERT INTO public.users_to_organizations (
-    user_id, 
-    organization_id, 
-    role, 
+    user_id,
+    organization_id,
+    role,
     status,
-    sharing_setting, 
-    edit_sql, 
-    upload_csv, 
-    export_assets, 
-    email_slack_enabled, 
-    created_at, 
-    updated_at, 
-    deleted_at, 
-    created_by, 
-    updated_by, 
+    sharing_setting,
+    edit_sql,
+    upload_csv,
+    export_assets,
+    email_slack_enabled,
+    created_at,
+    updated_at,
+    deleted_at,
+    created_by,
+    updated_by,
     deleted_by
 ) VALUES 
-('c2dd64cd-f7f3-4884-bc91-d46ae431901e', 'bf58d19a-8bb9-4f1d-a257-2d2105e7f1ce', 'workspace_admin', 'active', 'public', false, false, false, false, '2024-11-05 15:41:13.958254+00', '2024-11-05 15:41:13.958254+00', NULL, 'c2dd64cd-f7f3-4884-bc91-d46ae431901e', 'c2dd64cd-f7f3-4884-bc91-d46ae431901e', NULL),
-('1fe85021-e799-471b-8837-953e9ae06e4c', 'bf58d19a-8bb9-4f1d-a257-2d2105e7f1ce', 'querier', 'active', 'team', false, false, false, false, '2024-11-05 15:41:13.958255+00', '2024-11-05 15:41:13.958255+00', NULL, '1fe85021-e799-471b-8837-953e9ae06e4c', '1fe85021-e799-471b-8837-953e9ae06e4c', NULL),
-('6840fa04-c0d7-4e0e-8d3d-ea9190d93874', 'bf58d19a-8bb9-4f1d-a257-2d2105e7f1ce', 'data_admin', 'active', 'public', false, false, false, false, '2024-11-05 15:41:13.958256+00', '2024-11-05 15:41:13.958256+00', NULL, '6840fa04-c0d7-4e0e-8d3d-ea9190d93874', '6840fa04-c0d7-4e0e-8d3d-ea9190d93874', NULL);
+('c2dd64cd-f7f3-4884-bc91-d46ae431901e', 'bf58d19a-8bb9-4f1d-a257-2d2105e7f1ce', 'workspace_admin', 'active', 'none', false, false, false, false, '2024-11-05 15:41:13.958254+00', '2024-11-05 15:41:13.958254+00', NULL, 'c2dd64cd-f7f3-4884-bc91-d46ae431901e', 'c2dd64cd-f7f3-4884-bc91-d46ae431901e', NULL),
+('1fe85021-e799-471b-8837-953e9ae06e4c', 'bf58d19a-8bb9-4f1d-a257-2d2105e7f1ce', 'querier', 'active', 'none', false, false, false, false, '2024-11-05 15:41:13.958255+00', '2024-11-05 15:41:13.958255+00', NULL, '1fe85021-e799-471b-8837-953e9ae06e4c', '1fe85021-e799-471b-8837-953e9ae06e4c', NULL),
+('6840fa04-c0d7-4e0e-8d3d-ea9190d93874', 'bf58d19a-8bb9-4f1d-a257-2d2105e7f1ce', 'data_admin', 'active', 'none', false, false, false, false, '2024-11-05 15:41:13.958256+00', '2024-11-05 15:41:13.958256+00', NULL, '6840fa04-c0d7-4e0e-8d3d-ea9190d93874', '6840fa04-c0d7-4e0e-8d3d-ea9190d93874', NULL);
 
 
 

--- a/api/src/routes/rest/routes/permission_groups/list_permission_groups.rs
+++ b/api/src/routes/rest/routes/permission_groups/list_permission_groups.rs
@@ -9,7 +9,8 @@ use uuid::Uuid;
 
 use crate::database::lib::get_pg_pool;
 use crate::database::models::{PermissionGroup, User};
-use crate::database::schema::permission_groups;
+use crate::database::schema::{permission_groups, permission_groups_to_identities, dataset_permissions, dataset_groups_permissions};
+use crate::database::enums::IdentityType;
 use crate::routes::rest::ApiResponse;
 use crate::utils::user::user_info::get_user_organization_id;
 
@@ -22,6 +23,9 @@ pub struct PermissionGroupInfo {
     pub updated_by: Uuid,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub user_count: i64,
+    pub dataset_count: i64,
+    pub dataset_group_count: i64,
 }
 
 pub async fn list_permission_groups(
@@ -45,23 +49,79 @@ async fn list_permission_groups_handler(user: User) -> Result<Vec<PermissionGrou
     let mut conn = get_pg_pool().get().await?;
     let organization_id = get_user_organization_id(&user.id).await?;
 
-    let permission_groups: Vec<PermissionGroup> = permission_groups::table
+    let permission_groups = permission_groups::table
+        .left_join(
+            permission_groups_to_identities::table.on(
+                permission_groups_to_identities::permission_group_id
+                    .eq(permission_groups::id)
+                    .and(permission_groups_to_identities::deleted_at.is_null())
+                    .and(permission_groups_to_identities::identity_type.eq(IdentityType::User))
+            ),
+        )
+        .left_join(
+            dataset_permissions::table.on(
+                dataset_permissions::permission_id
+                    .eq(permission_groups::id)
+                    .and(dataset_permissions::permission_type.eq("permission_group"))
+                    .and(dataset_permissions::deleted_at.is_null())
+            ),
+        )
+        .left_join(
+            dataset_groups_permissions::table.on(
+                dataset_groups_permissions::permission_id
+                    .eq(permission_groups::id)
+                    .and(dataset_groups_permissions::permission_type.eq("permission_group"))
+                    .and(dataset_groups_permissions::deleted_at.is_null())
+            ),
+        )
+        .group_by((
+            permission_groups::id,
+            permission_groups::name,
+            permission_groups::organization_id,
+            permission_groups::created_by,
+            permission_groups::updated_by,
+            permission_groups::created_at,
+            permission_groups::updated_at,
+        ))
+        .select((
+            permission_groups::id,
+            permission_groups::name,
+            permission_groups::organization_id,
+            permission_groups::created_by,
+            permission_groups::updated_by,
+            permission_groups::created_at,
+            permission_groups::updated_at,
+            diesel::dsl::sql::<diesel::sql_types::BigInt>(
+                "COUNT(DISTINCT permission_groups_to_identities.identity_id)",
+            ),
+            diesel::dsl::sql::<diesel::sql_types::BigInt>(
+                "COUNT(DISTINCT dataset_permissions.dataset_id)",
+            ),
+            diesel::dsl::sql::<diesel::sql_types::BigInt>(
+                "COUNT(DISTINCT dataset_groups_permissions.dataset_group_id)",
+            ),
+        ))
         .filter(permission_groups::organization_id.eq(organization_id))
         .filter(permission_groups::deleted_at.is_null())
         .order_by(permission_groups::created_at.desc())
-        .load(&mut *conn)
+        .load::<(Uuid, String, Uuid, Uuid, Uuid, DateTime<Utc>, DateTime<Utc>, i64, i64, i64)>(&mut *conn)
         .await?;
 
     Ok(permission_groups
         .into_iter()
-        .map(|group| PermissionGroupInfo {
-            id: group.id,
-            name: group.name,
-            organization_id: group.organization_id,
-            created_by: group.created_by,
-            updated_by: group.updated_by,
-            created_at: group.created_at,
-            updated_at: group.updated_at,
+        .map(|(id, name, organization_id, created_by, updated_by, created_at, updated_at, user_count, dataset_count, dataset_group_count)| {
+            PermissionGroupInfo {
+                id,
+                name,
+                organization_id,
+                created_by,
+                updated_by,
+                created_at,
+                updated_at,
+                user_count,
+                dataset_count,
+                dataset_group_count,
+            }
         })
         .collect())
 }

--- a/api/src/routes/rest/routes/users/get_user_by_id.rs
+++ b/api/src/routes/rest/routes/users/get_user_by_id.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use axum::{extract::Path, Extension};
 use diesel_async::RunQueryDsl;
-use futures::future::try_join_all;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -92,6 +91,7 @@ pub async fn get_user_information(user_id: &Uuid) -> Result<UserResponse> {
                     users_to_organizations::organization_id,
         ))
         .filter(users::id.eq(user_id))
+        .filter(users_to_organizations::deleted_at.is_null())
         .first::<(
             (Uuid, String, Option<String>),
             (UserOrganizationRole, UserOrganizationStatus),
@@ -170,6 +170,7 @@ pub async fn get_user_information(user_id: &Uuid) -> Result<UserResponse> {
                 .filter(dataset_permissions::deleted_at.is_null())
                 .filter(permission_groups::deleted_at.is_null())
                 .filter(datasets::deleted_at.is_null())
+                .filter(permission_groups_to_identities::deleted_at.is_null())
                 .select((
                     datasets::id,
                     datasets::name,
@@ -209,6 +210,7 @@ pub async fn get_user_information(user_id: &Uuid) -> Result<UserResponse> {
                 )
                 .filter(users_to_organizations::user_id.eq(user_id))
                 .filter(datasets::deleted_at.is_null())
+                .filter(users_to_organizations::deleted_at.is_null())
                 .select((datasets::id, datasets::name))
                 .load::<(Uuid, String)>(&mut conn)
                 .await

--- a/api/src/routes/rest/routes/users/update_user.rs
+++ b/api/src/routes/rest/routes/users/update_user.rs
@@ -73,6 +73,10 @@ pub async fn update_user_handler(
         }
     };
 
+    if &auth_user.id == user_id {
+        return Err(anyhow::anyhow!("Cannot update self"));
+    };
+
     match is_user_workspace_admin_or_data_admin(auth_user, &user_organization_id).await {
         Ok(true) => (),
         Ok(false) => return Err(anyhow::anyhow!("Insufficient permissions")),

--- a/api/src/routes/ws/dashboards/dashboard_utils.rs
+++ b/api/src/routes/ws/dashboards/dashboard_utils.rs
@@ -271,15 +271,8 @@ pub async fn get_user_dashboard_permission(
     };
 
     let permissions = match asset_permissions::table
-        .left_join(
-            teams_to_users::table.on(asset_permissions::identity_id.eq(teams_to_users::team_id)),
-        )
         .select(asset_permissions::role)
-        .filter(
-            asset_permissions::identity_id
-                .eq(&user_id)
-                .or(teams_to_users::user_id.eq(&user_id)),
-        )
+        .filter(asset_permissions::identity_id.eq(&user_id))
         .filter(asset_permissions::asset_id.eq(&dashboard_id))
         .filter(asset_permissions::deleted_at.is_null())
         .load::<AssetPermissionRole>(&mut conn)
@@ -322,15 +315,8 @@ pub async fn get_bulk_user_dashboard_permission(
     };
 
     let permissions = match asset_permissions::table
-        .left_join(
-            teams_to_users::table.on(asset_permissions::identity_id.eq(teams_to_users::team_id)),
-        )
         .select((asset_permissions::asset_id, asset_permissions::role))
-        .filter(
-            asset_permissions::identity_id
-                .eq(&user_id)
-                .or(teams_to_users::user_id.eq(&user_id)),
-        )
+        .filter(asset_permissions::identity_id.eq(&user_id))
         .filter(asset_permissions::asset_id.eq_any(dashboard_ids))
         .filter(asset_permissions::deleted_at.is_null())
         .load::<(Uuid, AssetPermissionRole)>(&mut conn)

--- a/api/src/routes/ws/dashboards/list_dashboards.rs
+++ b/api/src/routes/ws/dashboards/list_dashboards.rs
@@ -115,13 +115,6 @@ async fn list_dashboards_handler(
                 .and(asset_permissions::asset_type.eq(AssetType::Dashboard))
                 .and(asset_permissions::deleted_at.is_null())),
         )
-        .left_join(
-            teams_to_users::table.on(asset_permissions::identity_id
-                .eq(teams_to_users::user_id)
-                .and(asset_permissions::identity_type.eq(IdentityType::Team))
-                .and(teams_to_users::deleted_at.is_null())
-                .and(asset_permissions::deleted_at.is_null())),
-        )
         .inner_join(users::table.on(users::id.eq(dashboards::created_by)))
         .select((
             dashboards::id,
@@ -133,11 +126,7 @@ async fn list_dashboards_handler(
             users::name.nullable(),
         ))
         .filter(dashboards::deleted_at.is_null())
-        .filter(
-            asset_permissions::identity_id
-                .eq(user_id)
-                .or(teams_to_users::user_id.eq(user_id)),
-        )
+        .filter(asset_permissions::identity_id.eq(user_id))
         .distinct()
         .order((dashboards::updated_at.desc(), dashboards::id.asc()))
         .offset(page * page_size)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refine permission checks and dataset access logic across modules to improve security and access control.
> 
>   - **Permission Checks**:
>     - Refine permission checks in `get_dataset_overview.rs` to ensure default access lineage is only added when no other access paths exist.
>     - Update `post_dataset.rs` to include organization ID in `post_dataset_handler()` and remove redundant admin access check.
>     - Add self-update restriction in `update_user.rs`.
>   - **Dataset Access**:
>     - Enhance dataset access logic in `list_datasets.rs` and `post_thread.rs` to handle direct, permission group, dataset group, and permission group to dataset group access.
>     - Modify `get_user_by_id.rs` to include dataset access through various permission paths.
>   - **Miscellaneous**:
>     - Update `get_permission_group.rs` and `list_permission_groups.rs` to include user, dataset, and dataset group counts.
>     - Remove team-based permission checks in `dashboard_utils.rs` and `list_dashboards.rs`.
>     - Adjust SQL queries in `get_user_by_id.rs` and `post_thread.rs` to ensure proper filtering and joining for permission checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=buster-so%2Fbuster&utm_source=github&utm_medium=referral)<sup> for 02edb025b8aa29bd370be497b442869999a8d4ef. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->