### PR TITLE
fix: headers config on vercel

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -17,6 +17,36 @@ const nextConfig = {
   reactStrictMode: false,
   sassOptions: {
     includePaths: [path.join(__dirname, 'styles')]
+  },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live https://*.vercel.app",
+              "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+              "img-src 'self' blob: data: https://*.vercel.app https://*.supabase.co",
+              "font-src 'self' https://fonts.gstatic.com",
+              "frame-ancestors 'none'",
+              "connect-src 'self' https://*.vercel.app https://*.supabase.co wss://*.supabase.co",
+              "media-src 'self'",
+              "object-src 'none'",
+              "form-action 'self'",
+              "base-uri 'self'",
+              "manifest-src 'self'"
+            ].join('; ')
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'SAMEORIGIN'
+          }
+        ]
+      }
+    ];
   }
 };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds headers configuration in `next.config.mjs` to set Content Security Policy and X-Frame-Options for all routes.
> 
>   - **Headers Configuration**:
>     - Adds `async headers()` function in `next.config.mjs` to set HTTP headers for all routes.
>     - Configures `Content-Security-Policy` to restrict sources for scripts, styles, images, fonts, and connections.
>     - Sets `X-Frame-Options` to `SAMEORIGIN` to prevent clickjacking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=buster-so%2Fbuster&utm_source=github&utm_medium=referral)<sup> for 39f2f94540d4c4c760e4290ac2e5105f37c095db. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->