### PR TITLE
upgrade(ai): update OpenAI model configurations and add support for O…

### DIFF
--- a/api/src/routes/ws/datasets/dataset_utils.rs
+++ b/api/src/routes/ws/datasets/dataset_utils.rs
@@ -551,7 +551,7 @@ Output in json with each key being the column name and the value being the descr
     );
 
     let col_descriptions = match llm_chat(
-        LlmModel::OpenAi(OpenAiChatModel::Gpt4o),
+        LlmModel::OpenAi(OpenAiChatModel::O3Mini),
         &vec![LlmMessage {
             role: LlmRole::User,
             content: user_message.clone(),
@@ -606,7 +606,7 @@ Output the description in JSON with 'when_to_use' and 'when_not_to_use' as the k
     );
 
     let select_term_response = match llm_chat(
-        LlmModel::OpenAi(OpenAiChatModel::Gpt4o),
+        LlmModel::OpenAi(OpenAiChatModel::O3Mini),
         &vec![LlmMessage {
             role: LlmRole::User,
             content: user_message.clone(),

--- a/api/src/routes/ws/threads_and_messages/post_thread/ai/ai_calls.rs
+++ b/api/src/routes/ws/threads_and_messages/post_thread/ai/ai_calls.rs
@@ -86,7 +86,7 @@ Output in json with the key of 'dataset' and the value of the dataset name. Your
     ];
 
     let response = match llm_chat(
-        LlmModel::OpenAi(OpenAiChatModel::Gpt4o),
+        LlmModel::OpenAi(OpenAiChatModel::O3Mini),
         &messages_to_be_sent,
         0.0,
         50,
@@ -175,7 +175,7 @@ Output in markdown (```sql```) format. Make sure to close the SQL statement with
     }
 
     let stream_response = match llm_chat_stream(
-        LlmModel::OpenAi(OpenAiChatModel::Gpt4o),
+        LlmModel::OpenAi(OpenAiChatModel::O3Mini),
         messages_to_be_sent,
         0.0,
         1000,
@@ -248,7 +248,7 @@ SQL should be escaped with backticks (```sql```) like in markdown format.",
     ];
 
     let stream_response = match llm_chat_stream(
-        LlmModel::OpenAi(OpenAiChatModel::Gpt4o),
+        LlmModel::OpenAi(OpenAiChatModel::O3Mini),
         messages_to_be_sent,
         0.0,
         1000,
@@ -332,7 +332,7 @@ No longer than 2 sentences.",
     }];
 
     let response = match llm_chat_stream(
-        LlmModel::OpenAi(OpenAiChatModel::Gpt4o),
+        LlmModel::OpenAi(OpenAiChatModel::O3Mini),
         messages_to_be_sent,
         0.0,
         250,
@@ -383,7 +383,7 @@ No longer than 2 sentences.",
     }];
 
     let stream_response = match llm_chat_stream(
-        LlmModel::OpenAi(OpenAiChatModel::Gpt4o),
+        LlmModel::OpenAi(OpenAiChatModel::O3Mini),
         messages_to_be_sent,
         0.0,
         250,
@@ -435,7 +435,7 @@ Speak casually.
     }];
 
     let stream_response = match llm_chat_stream(
-        LlmModel::OpenAi(OpenAiChatModel::Gpt4o),
+        LlmModel::OpenAi(OpenAiChatModel::O3Mini),
         messages_to_be_sent,
         0.0,
         250,
@@ -485,7 +485,7 @@ The title should contain no special characters.",
     }];
 
     let stream_response = match llm_chat_stream(
-        LlmModel::OpenAi(OpenAiChatModel::Gpt4o),
+        LlmModel::OpenAi(OpenAiChatModel::O3Mini),
         messages_to_be_sent,
         0.0,
         50,
@@ -535,7 +535,7 @@ The question should contain no special characters.",
     }];
 
     let stream_response = match llm_chat_stream(
-        LlmModel::OpenAi(OpenAiChatModel::Gpt4o),
+        LlmModel::OpenAi(OpenAiChatModel::O3Mini),
         messages_to_be_sent,
         0.0,
         50,
@@ -602,7 +602,7 @@ Just output the time frame in the format I mentioned above. Do not wrap in any s
     ];
 
     let stream_response = match llm_chat_stream(
-        LlmModel::OpenAi(OpenAiChatModel::Gpt4o),
+        LlmModel::OpenAi(OpenAiChatModel::O3Mini),
         messages_to_be_sent,
         0.0,
         100,
@@ -666,7 +666,7 @@ Output the results in a json object with 'terms' as the key and an array contain
     );
 
     let select_term_response = match llm_chat(
-        LlmModel::OpenAi(OpenAiChatModel::Gpt4o),
+        LlmModel::OpenAi(OpenAiChatModel::O3Mini),
         &vec![LlmMessage {
             role: LlmRole::User,
             content: user_message.clone(),

--- a/api/src/utils/agent_builder/nodes/prompt_node.rs
+++ b/api/src/utils/agent_builder/nodes/prompt_node.rs
@@ -64,9 +64,15 @@ impl fmt::Display for PromptNodeError {
 }
 
 pub async fn prompt_node(settings: PromptNodeSettings) -> Result<Value, ErrorNode> {
+    let model = match settings.model.as_str() {
+        "gpt-4o" => LlmModel::OpenAi(OpenAiChatModel::Gpt4o),
+        "gpt-3.5-turbo" => LlmModel::OpenAi(OpenAiChatModel::Gpt35Turbo),
+        _ => LlmModel::OpenAi(OpenAiChatModel::O3Mini),
+    };
+
     let llm_response = if let Some(stream) = settings.stream {
         let (mut llm_stream, response_future) = match llm_chat_stream(
-            LlmModel::OpenAi(OpenAiChatModel::Gpt4o),
+            model,
             settings
                 .messages
                 .into_iter()
@@ -137,7 +143,7 @@ pub async fn prompt_node(settings: PromptNodeSettings) -> Result<Value, ErrorNod
         }
     } else {
         let response = match llm_chat(
-            LlmModel::OpenAi(OpenAiChatModel::Gpt4o),
+            model,
             &settings
                 .messages
                 .into_iter()

--- a/api/src/utils/agents/configure_charts_agent.rs
+++ b/api/src/utils/agents/configure_charts_agent.rs
@@ -160,6 +160,7 @@ pub async fn configure_charts_agent(
         ],
         prompt_name: "bar_line_chart".to_string(),
         json_mode: true,
+        model: "gpt-4o".to_string(),
         ..Default::default()
     };
     let bar_line_future = tokio::spawn(async move { prompt_node(bar_line_chart_settings).await });
@@ -184,6 +185,7 @@ pub async fn configure_charts_agent(
         ],
         prompt_name: "scatter_chart".to_string(),
         json_mode: true,
+        model: "gpt-4o".to_string(),
         ..Default::default()
     };
     let scatter_future = tokio::spawn(async move { prompt_node(scatter_chart_settings).await });
@@ -208,6 +210,7 @@ pub async fn configure_charts_agent(
         ],
         prompt_name: "pie_chart".to_string(),
         json_mode: true,
+        model: "gpt-4o".to_string(),
         ..Default::default()
     };
     let pie_future = tokio::spawn(async move { prompt_node(pie_chart_settings).await });
@@ -232,6 +235,7 @@ pub async fn configure_charts_agent(
         ],
         prompt_name: "metric_chart".to_string(),
         json_mode: true,
+        model: "gpt-4o".to_string(),
         ..Default::default()
     };
     let metric_future = tokio::spawn(async move { prompt_node(metric_chart_settings).await });
@@ -257,6 +261,7 @@ pub async fn configure_charts_agent(
         messages,
         prompt_name: "combo_chart".to_string(),
         json_mode: true,
+        model: "gpt-4o".to_string(),
         ..Default::default()
     };
     let combo_future = tokio::spawn(async move { prompt_node(combo_chart_settings).await });

--- a/api/src/utils/clients/ai/langfuse.rs
+++ b/api/src/utils/clients/ai/langfuse.rs
@@ -27,7 +27,7 @@ impl LlmModel {
         let output_token = bpe.encode_with_special_tokens(&output);
 
         match self {
-            LlmModel::OpenAi(OpenAiChatModel::Gpt4o) => Usage {
+            LlmModel::OpenAi(OpenAiChatModel::O3Mini) => Usage {
                 input: input_token.len() as u32,
                 output: output_token.len() as u32,
                 unit: "TOKENS".to_string(),
@@ -45,7 +45,7 @@ impl LlmModel {
                 total_cost: (input_token.len() as f64 / 1_000_000.0) * 0.5
                     + (output_token.len() as f64 / 1_000_000.0) * 1.5,
             },
-            LlmModel::OpenAi(OpenAiChatModel::Gpt4oMini) => Usage {
+            LlmModel::OpenAi(OpenAiChatModel::Gpt4o) => Usage {
                 input: input_token.len() as u32,
                 output: output_token.len() as u32,
                 unit: "TOKENS".to_string(),

--- a/api/src/utils/prompts/generate_sql_prompts/sql_gen_prompt.rs
+++ b/api/src/utils/prompts/generate_sql_prompts/sql_gen_prompt.rs
@@ -27,6 +27,8 @@ Do not respond to the user telling them to use predictive modeling tooling in an
 
 Do not respond with an explanation of the SQL you are generating. Generate just the SQL.
 
+Please output the SQL delimited in ```sql tags.
+
 ### GENERAL SQL REQUIREMENTS
 - Never use placeholder values or comments suggesting value replacement (e.g. `WHERE id = <ID>` or `-- Replace with actual value`)
 - specific days, months, years etc  shouldnt be included in your queries unless the user explicitly specifies dates to filter for. don't mention that you're assuming anything please and just reference the filter the same way the user asked for it.

--- a/api/src/utils/prompts/modify_visualization_prompts/build_charts_prompts/metric_chart_prompt.rs
+++ b/api/src/utils/prompts/modify_visualization_prompts/build_charts_prompts/metric_chart_prompt.rs
@@ -6,7 +6,7 @@ pub fn metric_chart_system_prompt() -> String {
 type MetricChartProps = {
   metricColumnId: string; //the column name to use for the value. NEVER use ID columns for metrics
   metricHeader: string | DerivedMetricTitle | null; //OPTIONAL: if undefined, the column name will be used and formatted
-  metricValueAggregate?: 'sum' | 'average' | 'median' | 'max' | 'min' | 'count' | 'first'; //OPTIONAL: default: sum
+  metricValueAggregate?: 'sum' | 'average' | 'median' | 'max' | 'min' | 'count' | 'first'; //OPTIONAL: default: sum THIS SHOULD ALWAYS BE SUM UNLESS THE USER SPECIFIES OTHERWISE
   metricSubHeader?: string | DerivedMetricTitle | null; //OPTIONAL: default is ''
 };
 
@@ -41,6 +41,7 @@ You are an AI assistant that helps generate updated chart configurations based o
      - Avoid technical jargon unless necessary for the domain
    - For metric values:
      - Choose appropriate aggregation based on the metric type:
+      This should always be SUM unless the user specifies otherwise.
        - 'sum' for additive metrics (revenue, counts)
        - 'average' for rates and ratios
        - 'median' for skewed distributions


### PR DESCRIPTION
…3 Mini model

This commit introduces several changes to AI model handling:
- Replace GPT-4o with O3 Mini as the default model in various AI call contexts
- Update OpenAI client to support conditional serialization for O3 Mini
- Add model selection flexibility in prompt nodes
- Modify token usage calculations for new model
- Update chart configuration and SQL generation prompts
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update AI model configurations to use O3 Mini, add conditional serialization, and update prompts and token usage.
> 
>   - **Behavior**:
>     - Replace `Gpt4o` with `O3Mini` as the default model in `dataset_utils.rs`, `ai_calls.rs`, and `prompt_node.rs`.
>     - Update OpenAI client in `openai.rs` to support conditional serialization for `O3Mini`.
>     - Modify token usage calculations in `langfuse.rs` for `O3Mini`.
>   - **Prompt Nodes**:
>     - Add model selection flexibility in `prompt_node()` in `prompt_node.rs`.
>   - **Prompts**:
>     - Update chart configuration prompts in `configure_charts_agent.rs`.
>     - Update SQL generation prompts in `sql_gen_prompt.rs`.
>     - Modify metric chart prompts in `metric_chart_prompt.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=buster-so%2Fbuster&utm_source=github&utm_medium=referral)<sup> for df46db1395f8acd12e2ad77050d708c596397bd6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->