### PR TITLE
fix: janky check for values

### DIFF
--- a/api/src/utils/query_engine/data_source_query_routes/snowflake_query.rs
+++ b/api/src/utils/query_engine/data_source_query_routes/snowflake_query.rs
@@ -49,9 +49,12 @@ pub async fn snowflake_query(
 ) -> Result<Vec<IndexMap<std::string::String, DataType>>, Error> {
     const MAX_ROWS: usize = 5_000;
 
-    // Wrap the original query in a limit clause
-    // let limited_query = format!("SELECT * FROM ({}) tmp_query LIMIT {}", query.replace(";", ""), MAX_ROWS);
-    let limited_query = query;
+    let query_no_semicolon = query.trim_end_matches(';');
+    let limited_query = if !query_no_semicolon.to_lowercase().contains("limit") {
+        format!("{} FETCH FIRST {} ROWS ONLY", query_no_semicolon, MAX_ROWS)
+    } else {
+        query_no_semicolon.to_string()
+    };
 
     let rows = match snowflake_client.exec(&limited_query).await {
         Ok(result) => match result {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `snowflake_query` in `snowflake_query.rs` to append a limit clause to queries without one, ensuring a maximum of 5000 rows are returned.
> 
>   - **Behavior**:
>     - Modify `snowflake_query` in `snowflake_query.rs` to append `FETCH FIRST 5000 ROWS ONLY` to queries without a `limit` clause.
>     - Ensures queries do not exceed `MAX_ROWS` of 5000.
>   - **Misc**:
>     - Remove commented-out code for query limiting in `snowflake_query.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=buster-so%2Fbuster&utm_source=github&utm_medium=referral)<sup> for 960c89ab841116240a8fc6fb3fdbc52eb524bb67. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->