### PR TITLE
use colors in tooltip cache

### DIFF
--- a/api/src/utils/stored_values/mod.rs
+++ b/api/src/utils/stored_values/mod.rs
@@ -41,12 +41,12 @@ pub async fn ensure_stored_values_schema(organization_id: &Uuid) -> Result<()> {
     // Create schema and table using raw SQL
     let schema_name = organization_id.to_string().replace("-", "_");
     let create_schema_sql = format!(
-        "CREATE SCHEMA IF NOT EXISTS {}_values",
+        "CREATE SCHEMA IF NOT EXISTS values_{}",
         schema_name
     );
 
     let create_table_sql = format!(
-        "CREATE TABLE IF NOT EXISTS {}_values.values_v1 (
+        "CREATE TABLE IF NOT EXISTS values_{}.values_v1 (
             value text NOT NULL,
             dataset_id uuid NOT NULL,
             column_name text NOT NULL,
@@ -60,7 +60,7 @@ pub async fn ensure_stored_values_schema(organization_id: &Uuid) -> Result<()> {
 
     let create_index_sql = format!(
         "CREATE INDEX IF NOT EXISTS values_v1_embedding_idx 
-         ON {}_values.values_v1 
+         ON values_{}.values_v1 
          USING ivfflat (embedding vector_cosine_ops)",
         schema_name
     );

--- a/web/src/components/charts/BusterChartJS/hooks/useOptions/useOptions.tsx
+++ b/web/src/components/charts/BusterChartJS/hooks/useOptions/useOptions.tsx
@@ -169,7 +169,8 @@ export const useOptions = ({
     columnSettings,
     datasetOptions,
     hasMismatchedTooltipsAndMeasures,
-    disableTooltip
+    disableTooltip,
+    colors
   });
 
   const options: ChartProps<ChartJSChartType>['options'] = useMemo(() => {

--- a/web/src/components/charts/BusterChartJS/hooks/useOptions/useTooltipOptions.ts/useTooltipOptions.tsx
+++ b/web/src/components/charts/BusterChartJS/hooks/useOptions/useTooltipOptions.ts/useTooltipOptions.tsx
@@ -32,6 +32,7 @@ interface UseTooltipOptionsProps {
   datasetOptions: DatasetOption[];
   hasMismatchedTooltipsAndMeasures: boolean;
   disableTooltip: boolean;
+  colors: string[];
 }
 
 export const useTooltipOptions = ({
@@ -44,7 +45,8 @@ export const useTooltipOptions = ({
   columnSettings,
   selectedAxis,
   datasetOptions,
-  disableTooltip
+  disableTooltip,
+  colors
 }: UseTooltipOptionsProps): DeepPartial<TooltipOptions> => {
   const tooltipCache = useRef<Record<string, string>>({});
 
@@ -52,6 +54,10 @@ export const useTooltipOptions = ({
     () => JSON.stringify(columnLabelFormats),
     [columnLabelFormats]
   );
+
+  const colorsStringCache = useMemo(() => {
+    return colors.map((c) => String(c)).join('');
+  }, [colors]);
 
   const mode: TooltipOptions['mode'] = useMemo(() => {
     if (selectedChartType === 'scatter') {
@@ -107,7 +113,12 @@ export const useTooltipOptions = ({
   }, [useGlobalPercentage, selectedChartType, columnSettings, tooltipKeys]);
 
   const memoizedExternal = useMemoizedFn((context: TooltipContext) => {
-    const key = createTooltipCacheKey(context.chart, keyToUsePercentage, columnLabelFormatsString);
+    const key = createTooltipCacheKey(
+      context.chart,
+      keyToUsePercentage,
+      columnLabelFormatsString,
+      colorsStringCache
+    );
     const matchedCacheItem = tooltipCache.current[key];
     const result = externalTooltip(
       context,
@@ -149,7 +160,8 @@ export const useTooltipOptions = ({
 const createTooltipCacheKey = (
   chart: ChartJSOrUndefined,
   keyToUsePercentage: string[],
-  columnLabelFormatsString: string
+  columnLabelFormatsString: string,
+  colorsStringCache: string
 ) => {
   if (!chart?.tooltip) return '';
 
@@ -159,7 +171,8 @@ const createTooltipCacheKey = (
     chart.tooltip.title.join(''),
     chart.tooltip.body?.map((b) => b.lines.join('')).join(''),
     keyToUsePercentage.join(''),
-    columnLabelFormatsString
+    columnLabelFormatsString,
+    colorsStringCache
   ];
 
   return parts.join('');


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance tooltip caching by including color data in cache keys and update SQL schema creation in `mod.rs`.
> 
>   - **Tooltip Functionality**:
>     - Add `colors` to `UseTooltipOptionsProps` and `useTooltipOptions` in `useTooltipOptions.tsx`.
>     - Modify `createTooltipCacheKey` to include `colorsStringCache` in `useTooltipOptions.tsx`.
>     - Update `useOptions` to pass `colors` to `useTooltipOptions` in `useOptions.tsx`.
>   - **SQL Schema**:
>     - Change schema and table creation SQL in `ensure_stored_values_schema()` in `mod.rs` to use `values_{}` format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=buster-so%2Fbuster&utm_source=github&utm_medium=referral)<sup> for 2be738365652428b59bb59d24f68845bfd8fa132. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->