### PR TITLE
Tweaked the fix sql to return a json output so we don't get parse err…

### DIFF
--- a/api/src/utils/prompts/analyst_chat_prompts/failed_to_fix_sql_prompts.rs
+++ b/api/src/utils/prompts/analyst_chat_prompts/failed_to_fix_sql_prompts.rs
@@ -8,9 +8,11 @@ You should talk about how you tried to fix the SQL query three times, and that y
 
 At the end make sure to apologize to the user
 
-PLEASE OUTPUT THE SQL QUERY IN THE FOLLOWING FORMAT:
-```sql
-<sql_query>
+PLEASE OUTPUT THE SQL QUERY IN THE FOLLOWING JSON FORMAT:
+```json
+{
+  \"sql\": \"SELECT...\"
+}
 ```
 
 ### GENERAL GUIDELINES


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `failed_to_fix_sql_agent` to output SQL in JSON format and update prompts to prevent parsing errors.
> 
>   - **Behavior**:
>     - Modify `failed_to_fix_sql_agent` in `failed_to_fix_sql_agent.rs` to output SQL in JSON format to prevent parsing errors.
>     - Adjusts response handling to extract SQL from JSON and combine with other response parts.
>   - **Prompts**:
>     - Update `failed_to_fix_sql_system_prompt` in `failed_to_fix_sql_prompts.rs` to specify JSON format for SQL output.
>     - Modify `failed_to_fix_sql_user_prompt` to reflect new JSON format requirements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=buster-so%2Fbuster&utm_source=github&utm_medium=referral)<sup> for e144377ada901cc43b5e8091a58fb66f4136c553. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->