### PR TITLE
version on cli

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Get version
         id: get_version
         run: |
-          VERSION=$(cat version.txt)
+          VERSION=$(0.0.1)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Create Release


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Hardcode version to `0.0.1` in `cli-release.yml` instead of reading from `version.txt`.
> 
>   - **Workflow Change**:
>     - In `.github/workflows/cli-release.yml`, the `Get version` step now hardcodes the version to `0.0.1` instead of reading from `version.txt`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=buster-so%2Fbuster&utm_source=github&utm_medium=referral)<sup> for 3cf320075b4a0530c3e5eddf48bbccaf9315da47. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->