### PR TITLE
refactor: enhance data type handling in Redshift query processing

### DIFF
--- a/api/libs/query_engine/src/data_source_query_routes/redshift_query.rs
+++ b/api/libs/query_engine/src/data_source_query_routes/redshift_query.rs
@@ -38,7 +38,7 @@ pub async fn redshift_query(
                 "INT8" => DataType::Int8(row.try_get::<Option<i64>, _>(i).unwrap_or(None)),
                 "INT4" => DataType::Int4(row.try_get::<Option<i32>, _>(i).unwrap_or(None)),
                 "INT2" => DataType::Int2(row.try_get::<Option<i16>, _>(i).unwrap_or(None)),
-                "TEXT" | "VARCHAR" => DataType::Text(row.try_get::<Option<String>, _>(i).unwrap_or(None)),
+                "TEXT" | "VARCHAR" | "CHARACTER VARYING" => DataType::Text(row.try_get::<Option<String>, _>(i).unwrap_or(None)),
                 "FLOAT4" => DataType::Float4(row.try_get::<Option<f32>, _>(i).unwrap_or(None)),
                 "FLOAT8" => DataType::Float8(row.try_get::<Option<f64>, _>(i).unwrap_or(None)),
                 "NUMERIC" => {


### PR DESCRIPTION
- Added support for "CHARACTER VARYING" in data type retrieval to improve compatibility with Redshift.
- Maintained the use of `try_get` for safer option handling and consistent data type conversion.