### PR TITLE
Trim whitespace from chat inputs

### DIFF
--- a/apps/web/src/controllers/HomePage/NewChatInput.tsx
+++ b/apps/web/src/controllers/HomePage/NewChatInput.tsx
@@ -25,7 +25,8 @@ export const NewChatInput: React.FC<Record<string, never>> = () => {
     if (disabledSubmit) return;
     try {
       setLoading(true);
-      await onStartNewChat({ prompt: value });
+      const trimmedValue = value.trim();
+      await onStartNewChat({ prompt: trimmedValue });
     } catch (error) {
       setLoading(false);
     }

--- a/apps/web/src/layouts/ChatLayout/ChatContainer/ChatContent/ChatInput/useChatInputFlow.ts
+++ b/apps/web/src/layouts/ChatLayout/ChatContainer/ChatContent/ChatInput/useChatInputFlow.ts
@@ -49,16 +49,18 @@ export const useChatInputFlow = ({
       return;
     }
 
+    const trimmedInputValue = inputValue.trim();
+
     const method = async () => {
       switch (flow) {
         case 'followup-chat':
-          await onFollowUpChat({ prompt: inputValue, chatId });
+          await onFollowUpChat({ prompt: trimmedInputValue, chatId });
           break;
 
         case 'followup-metric':
           if (!selectedFileId) return;
           await onStartChatFromFile({
-            prompt: inputValue,
+            prompt: trimmedInputValue,
             fileId: selectedFileId,
             fileType: 'metric'
           });
@@ -66,14 +68,14 @@ export const useChatInputFlow = ({
         case 'followup-dashboard':
           if (!selectedFileId) return;
           await onStartChatFromFile({
-            prompt: inputValue,
+            prompt: trimmedInputValue,
             fileId: selectedFileId,
             fileType: 'dashboard'
           });
           break;
 
         case 'new':
-          await onStartNewChat({ prompt: inputValue });
+          await onStartNewChat({ prompt: trimmedInputValue });
           break;
 
         default: {


### PR DESCRIPTION
Trim leading and trailing whitespace from all chat input submissions to ensure cleaner and consistent user requests.