### PR TITLE
Fix loading state on button error

### DIFF
--- a/apps/web/src/components/features/layouts/AppVerticalCodeSplitter/SQLContainer.tsx
+++ b/apps/web/src/components/features/layouts/AppVerticalCodeSplitter/SQLContainer.tsx
@@ -41,14 +41,26 @@ export const SQLContainer: React.FC<{
 
     const onRunQueryPreflight = useMemoizedFn(async () => {
       setIsRunning(true);
-      await onRunQuery();
-      setIsRunning(false);
+      try {
+        await onRunQuery();
+      } catch (error) {
+        // Error handling is done by the parent component
+        console.error('Error running query:', error);
+      } finally {
+        setIsRunning(false);
+      }
     });
 
     const onSaveSQLPreflight = useMemoizedFn(async () => {
       setIsSaving(true);
-      await onSaveSQL?.();
-      setIsSaving(false);
+      try {
+        await onSaveSQL?.();
+      } catch (error) {
+        // Error handling is done by the parent component
+        console.error('Error saving SQL:', error);
+      } finally {
+        setIsSaving(false);
+      }
     });
 
     const memoizedFooter = useMemo(() => {


### PR DESCRIPTION
Ensure 'Run' and 'Save' buttons reset loading state on error by adding try-finally blocks.

The original implementation would leave the buttons stuck in a loading state if `onRunQuery()` or `onSaveSQL()` threw an error, as the `setIsRunning(false)` and `setIsSaving(false)` calls were not reached. This fix ensures the loading states are always reset.