### PR TITLE
Create route for fetching slack channels

### DIFF
--- a/apps/server/src/api/v2/slack/channels.int.test.ts
+++ b/apps/server/src/api/v2/slack/channels.int.test.ts
@@ -1,0 +1,278 @@
+import { db, slackIntegrations } from '@buster/database';
+import { eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import type { Context } from 'hono';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import slackRoutes from './index';
+import { cleanupTestOrgAndUser, createTestOrgAndUser } from './test-helpers';
+
+// Skip tests if required environment variables are not set
+const skipIfNoEnv =
+  !process.env.DATABASE_URL ||
+  !process.env.SLACK_CLIENT_ID ||
+  !process.env.SLACK_CLIENT_SECRET ||
+  !process.env.SLACK_REDIRECT_URI ||
+  !process.env.SUPABASE_URL ||
+  !process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  !process.env.SLACK_TEST_ACCESS_TOKEN; // Additional env var for testing channels
+
+// Mock the requireAuth middleware
+vi.mock('../../../middleware/auth', () => ({
+  requireAuth: (c: Context, next: () => Promise<void>) => {
+    return next();
+  },
+}));
+
+// Mock SlackChannelService if needed
+const mockChannels = [
+  { id: 'C1234567890', name: 'general', is_private: false, is_archived: false, is_member: true },
+  { id: 'C0987654321', name: 'random', is_private: false, is_archived: false, is_member: true },
+  { id: 'C1111111111', name: 'engineering', is_private: false, is_archived: false, is_member: false },
+];
+
+// Conditionally mock SlackChannelService based on environment
+if (!process.env.SLACK_TEST_ACCESS_TOKEN) {
+  vi.mock('@buster/slack', () => ({
+    SlackChannelService: vi.fn().mockImplementation(() => ({
+      getAvailableChannels: vi.fn().mockResolvedValue(mockChannels),
+    })),
+    SlackAuthService: vi.fn(),
+  }));
+}
+
+describe.skipIf(skipIfNoEnv)('Slack Channels Integration Tests', () => {
+  let app: Hono;
+  let testOrganizationId: string;
+  let testUserId: string;
+  const createdIntegrationIds: string[] = [];
+  const testRunId = Date.now().toString();
+
+  beforeAll(async () => {
+    if (skipIfNoEnv) {
+      console.log('Skipping Slack channels integration tests - required environment variables not set');
+      return;
+    }
+
+    // Create unique test organization and user
+    const { organizationId, userId } = await createTestOrgAndUser();
+    testOrganizationId = organizationId;
+    testUserId = userId;
+
+    if (process.env.SLACK_TEST_ACCESS_TOKEN) {
+      console.log('Running with real Slack API access token');
+    } else {
+      console.log('Running with mocked Slack responses');
+    }
+  });
+
+  beforeEach(async () => {
+    if (!skipIfNoEnv) {
+      // Clean up any existing active integrations
+      try {
+        await db
+          .delete(slackIntegrations)
+          .where(eq(slackIntegrations.organizationId, testOrganizationId));
+      } catch (error) {
+        console.error('Error cleaning up integrations:', error);
+      }
+
+      // Create a new Hono app for each test
+      app = new Hono();
+
+      // Add middleware to set auth context
+      app.use('*', async (c, next) => {
+        const path = c.req.path;
+        if (path.includes('/channels')) {
+          (c as Context).set('busterUser', { id: testUserId });
+          (c as Context).set('organizationId', testOrganizationId);
+        }
+        await next();
+      });
+
+      // Mount the Slack routes
+      app.route('/api/v2/slack', slackRoutes);
+    }
+  });
+
+  afterAll(async () => {
+    // Clean up all test data
+    if (!skipIfNoEnv && testOrganizationId && testUserId) {
+      await cleanupTestOrgAndUser(testOrganizationId, testUserId);
+    }
+  });
+
+  describe('GET /api/v2/slack/channels', () => {
+    it('should return 404 when no integration exists', async () => {
+      const response = await app.request('/api/v2/slack/channels', {
+        method: 'GET',
+      });
+
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data.error).toBe('No active Slack integration found');
+      expect(data.code).toBe('INTEGRATION_NOT_FOUND');
+    });
+
+    it('should return channels for active integration', async () => {
+      // Create an active integration with a token
+      const tokenVaultKey = `test-token-${testRunId}-${Date.now()}`;
+      
+      // If we have a real token, store it in the vault
+      if (process.env.SLACK_TEST_ACCESS_TOKEN) {
+        const { createSecret } = await import('@buster/database');
+        await createSecret({
+          secret: process.env.SLACK_TEST_ACCESS_TOKEN,
+          name: tokenVaultKey,
+          description: 'Test Slack OAuth token',
+        });
+      }
+
+      const [integration] = await db
+        .insert(slackIntegrations)
+        .values({
+          organizationId: testOrganizationId,
+          userId: testUserId,
+          status: 'active',
+          teamId: `T${testRunId}-channels`,
+          teamName: 'Test Workspace',
+          teamDomain: 'test-workspace',
+          botUserId: `U${testRunId}-bot`,
+          scope: 'channels:read',
+          tokenVaultKey,
+          installedAt: new Date().toISOString(),
+        })
+        .returning();
+
+      createdIntegrationIds.push(integration.id);
+
+      const response = await app.request('/api/v2/slack/channels', {
+        method: 'GET',
+      });
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.channels).toBeDefined();
+      expect(Array.isArray(data.channels)).toBe(true);
+      
+      // Each channel should have id and name
+      if (data.channels.length > 0) {
+        expect(data.channels[0]).toHaveProperty('id');
+        expect(data.channels[0]).toHaveProperty('name');
+        // Should not have other properties (only id and name as requested)
+        expect(Object.keys(data.channels[0])).toEqual(['id', 'name']);
+      }
+
+      // Clean up the secret if we created one
+      if (process.env.SLACK_TEST_ACCESS_TOKEN) {
+        const { deleteSecret, getSecretByName } = await import('@buster/database');
+        const secret = await getSecretByName(tokenVaultKey);
+        if (secret) {
+          await deleteSecret(secret.id);
+        }
+      }
+    });
+
+    it('should update last used timestamp when fetching channels', async () => {
+      // Create an active integration
+      const tokenVaultKey = `test-token-lastused-${testRunId}-${Date.now()}`;
+      
+      const [integration] = await db
+        .insert(slackIntegrations)
+        .values({
+          organizationId: testOrganizationId,
+          userId: testUserId,
+          status: 'active',
+          teamId: `T${testRunId}-lastused`,
+          teamName: 'Test Workspace',
+          teamDomain: 'test-workspace',
+          botUserId: `U${testRunId}-bot`,
+          scope: 'channels:read',
+          tokenVaultKey,
+          installedAt: new Date().toISOString(),
+          lastUsedAt: null, // Initially null
+        })
+        .returning();
+
+      createdIntegrationIds.push(integration.id);
+
+      await app.request('/api/v2/slack/channels', {
+        method: 'GET',
+      });
+
+      // Check that lastUsedAt was updated
+      const [updated] = await db
+        .select()
+        .from(slackIntegrations)
+        .where(eq(slackIntegrations.id, integration.id));
+
+      expect(updated.lastUsedAt).toBeTruthy();
+      expect(new Date(updated.lastUsedAt!).getTime()).toBeGreaterThan(
+        new Date(integration.createdAt).getTime()
+      );
+    });
+
+    it('should return 503 when integration is disabled', async () => {
+      // Temporarily disable the integration
+      const originalEnabled = process.env.SLACK_INTEGRATION_ENABLED;
+      process.env.SLACK_INTEGRATION_ENABLED = 'false';
+
+      // Need to clear the module cache and re-import
+      vi.resetModules();
+      const { default: freshRoutes } = await import('./index');
+
+      // Create a fresh app instance
+      const testApp = new Hono();
+      testApp.use('*', async (c, next) => {
+        if (c.req.path.includes('/channels')) {
+          (c as Context).set('busterUser', { id: testUserId });
+          (c as Context).set('organizationId', testOrganizationId);
+        }
+        await next();
+      });
+      testApp.route('/api/v2/slack', freshRoutes);
+
+      const response = await testApp.request('/api/v2/slack/channels', {
+        method: 'GET',
+      });
+
+      expect(response.status).toBe(503);
+      const data = await response.json();
+      expect(data.error).toBe('Slack integration is not configured');
+      expect(data.code).toBe('INTEGRATION_NOT_CONFIGURED');
+
+      // Restore original value
+      process.env.SLACK_INTEGRATION_ENABLED = originalEnabled;
+      vi.resetModules();
+    });
+
+    it('should handle token retrieval errors', async () => {
+      // Create an integration with a non-existent token key
+      const [integration] = await db
+        .insert(slackIntegrations)
+        .values({
+          organizationId: testOrganizationId,
+          userId: testUserId,
+          status: 'active',
+          teamId: `T${testRunId}-notoken`,
+          teamName: 'Test Workspace',
+          teamDomain: 'test-workspace',
+          botUserId: `U${testRunId}-bot`,
+          scope: 'channels:read',
+          tokenVaultKey: 'non-existent-token-key',
+          installedAt: new Date().toISOString(),
+        })
+        .returning();
+
+      createdIntegrationIds.push(integration.id);
+
+      const response = await app.request('/api/v2/slack/channels', {
+        method: 'GET',
+      });
+
+      expect(response.status).toBe(500);
+      const data = await response.json();
+      expect(data.error).toBe('Failed to retrieve authentication token');
+      expect(data.code).toBe('TOKEN_RETRIEVAL_ERROR');
+    });
+  });
+});

--- a/apps/server/src/api/v2/slack/index.ts
+++ b/apps/server/src/api/v2/slack/index.ts
@@ -9,6 +9,7 @@ const app = new Hono()
   .get('/auth/callback', (c) => slackHandler.handleOAuthCallback(c))
   // Protected endpoints
   .get('/integration', requireAuth, (c) => slackHandler.getIntegration(c))
+  .get('/channels', requireAuth, (c) => slackHandler.getChannels(c))
   .delete('/integration', requireAuth, (c) => slackHandler.removeIntegration(c))
   // Error handling
   .onError((e, c) => {


### PR DESCRIPTION
Add a new route to fetch public Slack channel IDs and names in real-time for a given integration.

This fulfills the requirement to retrieve channels on demand without storing them. An integration test is included, which skips execution if a `SLACK_TEST_ACCESS_TOKEN` is not provided in the environment.