### PR TITLE
Enhance metric fetching with user context and permission handling

### DIFF
--- a/apps/api/libs/handlers/src/dashboards/get_dashboard_handler.rs
+++ b/apps/api/libs/handlers/src/dashboards/get_dashboard_handler.rs
@@ -259,14 +259,14 @@ pub async fn get_dashboard_handler(
         })
         .collect();
 
-    // Fetch metrics concurrently using get_metric_handler
+    // Fetch metrics concurrently using get_metric_for_dashboard_handler with user context
     let mut metric_fetch_handles = Vec::new();
     for metric_id in metric_ids {
-        // Spawn a task for each metric fetch using the dashboard-specific handler.
-        // Pass only the metric_id and None for version_number.
+        // Clone user for each spawned task
+        let user_clone = user.clone();
         let handle = tokio::spawn(async move {
-            // Call the new handler, no user or password needed
-            get_metric_for_dashboard_handler(&metric_id, None).await
+            // Pass user context and None for version_number and password
+            get_metric_for_dashboard_handler(&metric_id, &user_clone, None, None).await
         });
         metric_fetch_handles.push((metric_id, handle));
     }

--- a/apps/api/libs/handlers/src/metrics/get_metric_data_handler.rs
+++ b/apps/api/libs/handlers/src/metrics/get_metric_data_handler.rs
@@ -104,7 +104,9 @@ pub async fn get_metric_data_handler(
                     tracing::info!("Found associated public dashboard. Fetching metric definition without direct permissions.");
                     match get_metric_for_dashboard_handler(
                         &request.metric_id,
+                        &user,
                         request.version_number,
+                        request.password.clone(),
                     )
                     .await
                     {


### PR DESCRIPTION
- Updated `get_dashboard_handler` to pass user context when fetching metrics.
- Modified `get_metric_data_handler` to include user information for metric definition retrieval.
- Refactored `get_metric_for_dashboard_handler` to enforce permission checks based on user roles and public access rules.
- Introduced user permission filtering in dashboard and collection fetching functions.
- Improved error handling and logging for permission-related issues.