### PR TITLE
Ensure column names are lowercase in data metadata for casing reliability

### DIFF
--- a/packages/ai/src/tools/visualization-tools/create-metrics-file-tool.ts
+++ b/packages/ai/src/tools/visualization-tools/create-metrics-file-tool.ts
@@ -153,7 +153,7 @@ function createDataMetadata(results: Record<string, unknown>[]): DataMetadata {
     const uniqueValues = new Set(values).size;
 
     columnMetadata.push({
-      name: columnName,
+      name: columnName.toLowerCase(),
       min_value: minValue,
       max_value: maxValue,
       unique_values: uniqueValues,

--- a/packages/ai/src/tools/visualization-tools/modify-metrics-file-tool.ts
+++ b/packages/ai/src/tools/visualization-tools/modify-metrics-file-tool.ts
@@ -145,7 +145,7 @@ function createDataMetadata(results: Record<string, unknown>[]): DataMetadata {
     const uniqueValues = new Set(values).size;
 
     columnMetadata.push({
-      name: columnName,
+      name: columnName.toLowerCase(),
       min_value: minValue,
       max_value: maxValue,
       unique_values: uniqueValues,


### PR DESCRIPTION
Make column names lowercase in metrics file tools' metadata for consistency with app-wide defaults.