### PR TITLE
Update chunk processor to return todo file type

### DIFF
--- a/packages/ai/src/utils/database/chunk-processor.ts
+++ b/packages/ai/src/utils/database/chunk-processor.ts
@@ -1654,7 +1654,7 @@ export class ChunkProcessor<T extends ToolSet = GenericToolSet> {
           files: {
             [fileId]: {
               id: fileId,
-              file_type: 'agent-action',
+              file_type: 'todo',
               file_name: 'TODO list',
               version_number: 1,
               status: 'loading',


### PR DESCRIPTION
Update `chunk-processor.ts` to return `file_type: 'todo'` instead of `agent-action` for todo lists.