### PR TITLE
Filter out records without titles

### DIFF
--- a/apps/api/libs/handlers/src/chats/list_chats_handler.rs
+++ b/apps/api/libs/handlers/src/chats/list_chats_handler.rs
@@ -106,6 +106,7 @@ pub async fn list_chats_handler(
         .inner_join(users::table.on(chats::created_by.eq(users::id)))
         .filter(chats::deleted_at.is_null())
         .filter(chats::title.ne("")) // Filter out empty titles
+        .filter(chats::title.ne(" ")) // Filter out single space
         .into_boxed();
     
     // Add user filter if not admin view
@@ -143,6 +144,7 @@ pub async fn list_chats_handler(
     let has_more = results.len() > request.page_size as usize;
     let items: Vec<ChatListItem> = results
         .into_iter()
+        .filter(|chat| !chat.title.trim().is_empty()) // Filter out titles with only whitespace
         .take(request.page_size as usize)
         .map(|chat| {
             ChatListItem {

--- a/apps/api/libs/handlers/src/chats/list_chats_handler.rs
+++ b/apps/api/libs/handlers/src/chats/list_chats_handler.rs
@@ -106,7 +106,6 @@ pub async fn list_chats_handler(
         .inner_join(users::table.on(chats::created_by.eq(users::id)))
         .filter(chats::deleted_at.is_null())
         .filter(chats::title.ne("")) // Filter out empty titles
-        .filter(chats::title.ne(" ")) // Filter out single space
         .into_boxed();
     
     // Add user filter if not admin view

--- a/apps/api/libs/handlers/src/chats/list_chats_handler.rs
+++ b/apps/api/libs/handlers/src/chats/list_chats_handler.rs
@@ -54,7 +54,7 @@ pub struct ListChatsResponse {
 struct ChatWithUser {
     // Chat fields
     pub id: Uuid,
-    pub name: String,
+    pub title: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub created_by: Uuid,
@@ -105,6 +105,7 @@ pub async fn list_chats_handler(
     let mut query = chats::table
         .inner_join(users::table.on(chats::created_by.eq(users::id)))
         .filter(chats::deleted_at.is_null())
+        .filter(chats::title.ne("")) // Filter out empty titles
         .into_boxed();
     
     // Add user filter if not admin view
@@ -146,7 +147,7 @@ pub async fn list_chats_handler(
         .map(|chat| {
             ChatListItem {
                 id: chat.id.to_string(),
-                name: chat.name,
+                name: chat.title,
                 is_favorited: false, // TODO: Implement favorites feature
                 created_at: chat.created_at.to_rfc3339(),
                 updated_at: chat.updated_at.to_rfc3339(),

--- a/apps/api/libs/handlers/src/logs/list_logs_handler.rs
+++ b/apps/api/libs/handlers/src/logs/list_logs_handler.rs
@@ -79,6 +79,7 @@ pub async fn list_logs_handler(
         .filter(chats::deleted_at.is_null())
         .filter(chats::organization_id.eq(organization_id))
         .filter(chats::title.ne("")) // Filter out empty titles
+        .filter(chats::title.ne(" ")) // Filter out single space
         .into_boxed();
 
     // Calculate offset based on page number
@@ -112,6 +113,7 @@ pub async fn list_logs_handler(
     let has_more = results.len() > request.page_size as usize;
     let items: Vec<LogListItem> = results
         .into_iter()
+        .filter(|chat| !chat.title.trim().is_empty()) // Filter out titles with only whitespace
         .take(request.page_size as usize)
         .map(|chat| {
             LogListItem {

--- a/apps/api/libs/handlers/src/logs/list_logs_handler.rs
+++ b/apps/api/libs/handlers/src/logs/list_logs_handler.rs
@@ -78,6 +78,7 @@ pub async fn list_logs_handler(
         .inner_join(users::table.on(chats::created_by.eq(users::id)))
         .filter(chats::deleted_at.is_null())
         .filter(chats::organization_id.eq(organization_id))
+        .filter(chats::title.ne("")) // Filter out empty titles
         .into_boxed();
 
     // Calculate offset based on page number


### PR DESCRIPTION
Filter out chat and log records with empty or whitespace-only titles from API responses to prevent UI display issues, and correct a field name inconsistency in `list_chats_handler`.