### PR TITLE
Implement chat access checks for metrics and dashboards

### DIFF
--- a/apps/api/libs/handlers/src/dashboards/get_dashboard_handler.rs
+++ b/apps/api/libs/handlers/src/dashboards/get_dashboard_handler.rs
@@ -147,48 +147,61 @@ pub async fn get_dashboard_handler(
             tracing::debug!(dashboard_id = %dashboard_id, user_id = %user.id, ?permission, "Granting access via direct permission.");
         }
     } else {
-        // No sufficient direct/admin permission, check public access rules
-        tracing::debug!(dashboard_id = %dashboard_id, "Insufficient direct/admin permission. Checking public access rules.");
-        if !dashboard_file.publicly_accessible {
-            tracing::warn!(dashboard_id = %dashboard_id, user_id = %user.id, "Permission denied (not public, insufficient direct permission).");
-            return Err(anyhow!("You don't have permission to view this dashboard"));
-        }
-        tracing::debug!(dashboard_id = %dashboard_id, "Dashboard is publicly accessible.");
-
-        // Check if the public access has expired
-        if let Some(expiry_date) = dashboard_file.public_expiry_date {
-            tracing::debug!(dashboard_id = %dashboard_id, ?expiry_date, "Checking expiry date");
-            if expiry_date < chrono::Utc::now() {
-                tracing::warn!(dashboard_id = %dashboard_id, "Public access expired");
-                return Err(anyhow!("Public access to this dashboard has expired"));
-            }
-        }
-
-        // Check if a password is required
-        tracing::debug!(dashboard_id = %dashboard_id, has_password = dashboard_file.public_password.is_some(), "Checking password requirement");
-        if let Some(required_password) = &dashboard_file.public_password {
-            tracing::debug!(dashboard_id = %dashboard_id, "Password required. Checking provided password.");
-            match password {
-                Some(provided_password) => {
-                    if provided_password != *required_password {
-                        // Incorrect password provided
-                        tracing::warn!(dashboard_id = %dashboard_id, user_id = %user.id, "Incorrect public password provided");
-                        return Err(anyhow!("Incorrect password for public access"));
-                    }
-                    // Correct password provided, grant CanView via public access
-                    tracing::debug!(dashboard_id = %dashboard_id, user_id = %user.id, "Correct public password provided. Granting CanView.");
-                    permission = AssetPermissionRole::CanView;
-                }
-                None => {
-                    // Password required but none provided
-                    tracing::warn!(dashboard_id = %dashboard_id, user_id = %user.id, "Public password required but none provided");
-                    return Err(anyhow!("public_password required for this dashboard"));
-                }
-            }
-        } else {
-            // Publicly accessible, not expired, and no password required
-            tracing::debug!(dashboard_id = %dashboard_id, "Public access granted (no password required).");
+        // No sufficient direct/admin permission, check if user has access via a chat
+        tracing::debug!(dashboard_id = %dashboard_id, "Insufficient direct/admin permission. Checking chat access.");
+        
+        let has_chat_access = sharing::check_dashboard_chat_access(dashboard_id, &user.id)
+            .await
+            .unwrap_or(false);
+            
+        if has_chat_access {
+            // User has access to a chat containing this dashboard, grant CanView
+            tracing::debug!(dashboard_id = %dashboard_id, user_id = %user.id, "User has access via chat. Granting CanView.");
             permission = AssetPermissionRole::CanView;
+        } else {
+            // No chat access either, check public access rules
+            tracing::debug!(dashboard_id = %dashboard_id, "No chat access. Checking public access rules.");
+            if !dashboard_file.publicly_accessible {
+                tracing::warn!(dashboard_id = %dashboard_id, user_id = %user.id, "Permission denied (not public, no chat access, insufficient direct permission).");
+                return Err(anyhow!("You don't have permission to view this dashboard"));
+            }
+            tracing::debug!(dashboard_id = %dashboard_id, "Dashboard is publicly accessible.");
+
+            // Check if the public access has expired
+            if let Some(expiry_date) = dashboard_file.public_expiry_date {
+                tracing::debug!(dashboard_id = %dashboard_id, ?expiry_date, "Checking expiry date");
+                if expiry_date < chrono::Utc::now() {
+                    tracing::warn!(dashboard_id = %dashboard_id, "Public access expired");
+                    return Err(anyhow!("Public access to this dashboard has expired"));
+                }
+            }
+
+            // Check if a password is required
+            tracing::debug!(dashboard_id = %dashboard_id, has_password = dashboard_file.public_password.is_some(), "Checking password requirement");
+            if let Some(required_password) = &dashboard_file.public_password {
+                tracing::debug!(dashboard_id = %dashboard_id, "Password required. Checking provided password.");
+                match password {
+                    Some(provided_password) => {
+                        if provided_password != *required_password {
+                            // Incorrect password provided
+                            tracing::warn!(dashboard_id = %dashboard_id, user_id = %user.id, "Incorrect public password provided");
+                            return Err(anyhow!("Incorrect password for public access"));
+                        }
+                        // Correct password provided, grant CanView via public access
+                        tracing::debug!(dashboard_id = %dashboard_id, user_id = %user.id, "Correct public password provided. Granting CanView.");
+                        permission = AssetPermissionRole::CanView;
+                    }
+                    None => {
+                        // Password required but none provided
+                        tracing::warn!(dashboard_id = %dashboard_id, user_id = %user.id, "Public password required but none provided");
+                        return Err(anyhow!("public_password required for this dashboard"));
+                    }
+                }
+            } else {
+                // Publicly accessible, not expired, and no password required
+                tracing::debug!(dashboard_id = %dashboard_id, "Public access granted (no password required).");
+                permission = AssetPermissionRole::CanView;
+            }
         }
     }
 

--- a/apps/api/libs/handlers/src/metrics/get_metric_for_dashboard_handler.rs
+++ b/apps/api/libs/handlers/src/metrics/get_metric_for_dashboard_handler.rs
@@ -169,48 +169,61 @@ pub async fn get_metric_for_dashboard_handler(
             tracing::debug!(metric_id = %metric_id, user_id = %user.id, "User has access via dashboard. Granting CanView.");
             permission = AssetPermissionRole::CanView;
         } else {
-            // No dashboard access, check public access rules
-            tracing::debug!(metric_id = %metric_id, "No dashboard access. Checking public access rules.");
-            if !metric_file.publicly_accessible {
-                tracing::warn!(metric_id = %metric_id, user_id = %user.id, "Permission denied (not public, no dashboard access, insufficient direct permission).");
-                return Err(anyhow!("You don't have permission to view this metric"));
-            }
-            tracing::debug!(metric_id = %metric_id, "Metric is publicly accessible.");
-
-            // Check if the public access has expired
-            if let Some(expiry_date) = metric_file.public_expiry_date {
-                tracing::debug!(metric_id = %metric_id, ?expiry_date, "Checking expiry date");
-                if expiry_date < chrono::Utc::now() {
-                    tracing::warn!(metric_id = %metric_id, "Public access expired");
-                    return Err(anyhow!("Public access to this metric has expired"));
-                }
-            }
-
-            // Check if a password is required
-            tracing::debug!(metric_id = %metric_id, has_password = metric_file.public_password.is_some(), "Checking password requirement");
-            if let Some(required_password) = &metric_file.public_password {
-                tracing::debug!(metric_id = %metric_id, "Password required. Checking provided password.");
-                match password {
-                    Some(provided_password) => {
-                        if provided_password != *required_password {
-                            // Incorrect password provided
-                            tracing::warn!(metric_id = %metric_id, user_id = %user.id, "Incorrect public password provided");
-                            return Err(anyhow!("Incorrect password for public access"));
-                        }
-                        // Correct password provided, grant CanView via public access
-                        tracing::debug!(metric_id = %metric_id, user_id = %user.id, "Correct public password provided. Granting CanView.");
-                        permission = AssetPermissionRole::CanView;
-                    }
-                    None => {
-                        // Password required but none provided
-                        tracing::warn!(metric_id = %metric_id, user_id = %user.id, "Public password required but none provided");
-                        return Err(anyhow!("public_password required for this metric"));
-                    }
-                }
-            } else {
-                // Publicly accessible, not expired, and no password required
-                tracing::debug!(metric_id = %metric_id, "Public access granted (no password required).");
+            // No dashboard access, check if user has access via a chat
+            tracing::debug!(metric_id = %metric_id, "No dashboard access. Checking chat access.");
+            
+            let has_chat_access = sharing::check_metric_chat_access(metric_id, &user.id)
+                .await
+                .unwrap_or(false);
+                
+            if has_chat_access {
+                // User has access to a chat containing this metric, grant CanView
+                tracing::debug!(metric_id = %metric_id, user_id = %user.id, "User has access via chat. Granting CanView.");
                 permission = AssetPermissionRole::CanView;
+            } else {
+                // No chat access either, check public access rules
+                tracing::debug!(metric_id = %metric_id, "No chat access. Checking public access rules.");
+                if !metric_file.publicly_accessible {
+                    tracing::warn!(metric_id = %metric_id, user_id = %user.id, "Permission denied (not public, no dashboard/chat access, insufficient direct permission).");
+                    return Err(anyhow!("You don't have permission to view this metric"));
+                }
+                tracing::debug!(metric_id = %metric_id, "Metric is publicly accessible.");
+
+                // Check if the public access has expired
+                if let Some(expiry_date) = metric_file.public_expiry_date {
+                    tracing::debug!(metric_id = %metric_id, ?expiry_date, "Checking expiry date");
+                    if expiry_date < chrono::Utc::now() {
+                        tracing::warn!(metric_id = %metric_id, "Public access expired");
+                        return Err(anyhow!("Public access to this metric has expired"));
+                    }
+                }
+
+                // Check if a password is required
+                tracing::debug!(metric_id = %metric_id, has_password = metric_file.public_password.is_some(), "Checking password requirement");
+                if let Some(required_password) = &metric_file.public_password {
+                    tracing::debug!(metric_id = %metric_id, "Password required. Checking provided password.");
+                    match password {
+                        Some(provided_password) => {
+                            if provided_password != *required_password {
+                                // Incorrect password provided
+                                tracing::warn!(metric_id = %metric_id, user_id = %user.id, "Incorrect public password provided");
+                                return Err(anyhow!("Incorrect password for public access"));
+                            }
+                            // Correct password provided, grant CanView via public access
+                            tracing::debug!(metric_id = %metric_id, user_id = %user.id, "Correct public password provided. Granting CanView.");
+                            permission = AssetPermissionRole::CanView;
+                        }
+                        None => {
+                            // Password required but none provided
+                            tracing::warn!(metric_id = %metric_id, user_id = %user.id, "Public password required but none provided");
+                            return Err(anyhow!("public_password required for this metric"));
+                        }
+                    }
+                } else {
+                    // Publicly accessible, not expired, and no password required
+                    tracing::debug!(metric_id = %metric_id, "Public access granted (no password required).");
+                    permission = AssetPermissionRole::CanView;
+                }
             }
         }
     }

--- a/apps/api/libs/handlers/src/metrics/get_metric_handler.rs
+++ b/apps/api/libs/handlers/src/metrics/get_metric_handler.rs
@@ -167,48 +167,61 @@ pub async fn get_metric_handler(
             tracing::debug!(metric_id = %metric_id, user_id = %user.id, "User has access via dashboard. Granting CanView.");
             permission = AssetPermissionRole::CanView;
         } else {
-            // No dashboard access, check public access rules
-            tracing::debug!(metric_id = %metric_id, "No dashboard access. Checking public access rules.");
-            if !metric_file.publicly_accessible {
-                tracing::warn!(metric_id = %metric_id, user_id = %user.id, "Permission denied (not public, no dashboard access, insufficient direct permission).");
-                return Err(anyhow!("You don't have permission to view this metric"));
-            }
-            tracing::debug!(metric_id = %metric_id, "Metric is publicly accessible.");
-
-            // Check if the public access has expired
-            if let Some(expiry_date) = metric_file.public_expiry_date {
-                tracing::debug!(metric_id = %metric_id, ?expiry_date, "Checking expiry date");
-                if expiry_date < chrono::Utc::now() {
-                    tracing::warn!(metric_id = %metric_id, "Public access expired");
-                    return Err(anyhow!("Public access to this metric has expired"));
-                }
-            }
-
-            // Check if a password is required
-            tracing::debug!(metric_id = %metric_id, has_password = metric_file.public_password.is_some(), "Checking password requirement");
-            if let Some(required_password) = &metric_file.public_password {
-                tracing::debug!(metric_id = %metric_id, "Password required. Checking provided password.");
-                match password {
-                    Some(provided_password) => {
-                        if provided_password != *required_password {
-                            // Incorrect password provided
-                            tracing::warn!(metric_id = %metric_id, user_id = %user.id, "Incorrect public password provided");
-                            return Err(anyhow!("Incorrect password for public access"));
-                        }
-                        // Correct password provided, grant CanView via public access
-                        tracing::debug!(metric_id = %metric_id, user_id = %user.id, "Correct public password provided. Granting CanView.");
-                        permission = AssetPermissionRole::CanView;
-                    }
-                    None => {
-                        // Password required but none provided
-                        tracing::warn!(metric_id = %metric_id, user_id = %user.id, "Public password required but none provided");
-                        return Err(anyhow!("public_password required for this metric"));
-                    }
-                }
-            } else {
-                // Publicly accessible, not expired, and no password required
-                tracing::debug!(metric_id = %metric_id, "Public access granted (no password required).");
+            // No dashboard access, check if user has access via a chat
+            tracing::debug!(metric_id = %metric_id, "No dashboard access. Checking chat access.");
+            
+            let has_chat_access = sharing::check_metric_chat_access(metric_id, &user.id)
+                .await
+                .unwrap_or(false);
+                
+            if has_chat_access {
+                // User has access to a chat containing this metric, grant CanView
+                tracing::debug!(metric_id = %metric_id, user_id = %user.id, "User has access via chat. Granting CanView.");
                 permission = AssetPermissionRole::CanView;
+            } else {
+                // No chat access either, check public access rules
+                tracing::debug!(metric_id = %metric_id, "No chat access. Checking public access rules.");
+                if !metric_file.publicly_accessible {
+                    tracing::warn!(metric_id = %metric_id, user_id = %user.id, "Permission denied (not public, no dashboard/chat access, insufficient direct permission).");
+                    return Err(anyhow!("You don't have permission to view this metric"));
+                }
+                tracing::debug!(metric_id = %metric_id, "Metric is publicly accessible.");
+
+                // Check if the public access has expired
+                if let Some(expiry_date) = metric_file.public_expiry_date {
+                    tracing::debug!(metric_id = %metric_id, ?expiry_date, "Checking expiry date");
+                    if expiry_date < chrono::Utc::now() {
+                        tracing::warn!(metric_id = %metric_id, "Public access expired");
+                        return Err(anyhow!("Public access to this metric has expired"));
+                    }
+                }
+
+                // Check if a password is required
+                tracing::debug!(metric_id = %metric_id, has_password = metric_file.public_password.is_some(), "Checking password requirement");
+                if let Some(required_password) = &metric_file.public_password {
+                    tracing::debug!(metric_id = %metric_id, "Password required. Checking provided password.");
+                    match password {
+                        Some(provided_password) => {
+                            if provided_password != *required_password {
+                                // Incorrect password provided
+                                tracing::warn!(metric_id = %metric_id, user_id = %user.id, "Incorrect public password provided");
+                                return Err(anyhow!("Incorrect password for public access"));
+                            }
+                            // Correct password provided, grant CanView via public access
+                            tracing::debug!(metric_id = %metric_id, user_id = %user.id, "Correct public password provided. Granting CanView.");
+                            permission = AssetPermissionRole::CanView;
+                        }
+                        None => {
+                            // Password required but none provided
+                            tracing::warn!(metric_id = %metric_id, user_id = %user.id, "Public password required but none provided");
+                            return Err(anyhow!("public_password required for this metric"));
+                        }
+                    }
+                } else {
+                    // Publicly accessible, not expired, and no password required
+                    tracing::debug!(metric_id = %metric_id, "Public access granted (no password required).");
+                    permission = AssetPermissionRole::CanView;
+                }
             }
         }
     }

--- a/apps/api/libs/sharing/src/lib.rs
+++ b/apps/api/libs/sharing/src/lib.rs
@@ -19,4 +19,4 @@ pub use types::{
     SerializableAssetPermission, UserInfo,
 };
 pub use user_lookup::find_user_by_email;
-pub use asset_access_checks::{check_permission_access, check_metric_dashboard_access};
+pub use asset_access_checks::{check_permission_access, check_metric_dashboard_access, check_metric_chat_access, check_dashboard_chat_access};


### PR DESCRIPTION
- Added functions to check if a user has access to metrics and dashboards through associated chats.
- Updated permission handling in `get_metric_data_handler`, `get_metric_for_dashboard_handler`, and `get_metric_handler` to include chat access checks.
- Enhanced error handling for cases where users lack access to both dashboards and chats.
- Updated `asset_access_checks` to include new chat access functions and modified the public interface in `lib.rs` accordingly.