### PR TITLE
fix: resolve unit test failures in server-shared and apps/server packages

### DIFF
--- a/apps/server/src/api/v2/slack/handler.test.ts
+++ b/apps/server/src/api/v2/slack/handler.test.ts
@@ -136,7 +136,7 @@ describe('SlackHandler', () => {
       await handler.handleOAuthCallback(mockContext);
 
       expect(mockContext.redirect).toHaveBeenCalledWith(
-        '/app/settings/integrations?status=cancelled'
+        'http://localhost:3000/app/settings/integrations?status=cancelled'
       );
     });
 
@@ -146,7 +146,7 @@ describe('SlackHandler', () => {
       await handler.handleOAuthCallback(mockContext);
 
       expect(mockContext.redirect).toHaveBeenCalledWith(
-        '/app/settings/integrations?status=error&error=invalid_parameters'
+        'http://localhost:3000/app/settings/integrations?status=error&error=invalid_parameters'
       );
     });
 
@@ -171,7 +171,7 @@ describe('SlackHandler', () => {
         state: 'test-state',
       });
       expect(mockContext.redirect).toHaveBeenCalledWith(
-        '/dashboard?status=success&workspace=Test%20Workspace'
+        'http://localhost:3000/dashboard?status=success&workspace=Test%20Workspace'
       );
     });
 
@@ -191,7 +191,7 @@ describe('SlackHandler', () => {
       await handler.handleOAuthCallback(mockContext);
 
       expect(mockContext.redirect).toHaveBeenCalledWith(
-        '/app/settings/integrations?status=error&error=invalid_state'
+        'http://localhost:3000/app/settings/integrations?status=error&error=invalid_state'
       );
     });
   });

--- a/packages/server-shared/src/metrics/metric.types.test.ts
+++ b/packages/server-shared/src/metrics/metric.types.test.ts
@@ -49,6 +49,8 @@ describe('MetricSchema', () => {
       publicly_accessible: false,
       public_password: null,
       permission: 'owner',
+      workspace_sharing: null,
+      workspace_member_count: null,
     };
 
     const result = MetricSchema.safeParse(validMetric);
@@ -112,6 +114,8 @@ describe('MetricSchema', () => {
       publicly_accessible: false,
       public_password: null,
       permission: 'canView',
+      workspace_sharing: null,
+      workspace_member_count: null,
       // chart_config is omitted, should get default
     };
 
@@ -191,6 +195,8 @@ describe('MetricSchema', () => {
       publicly_accessible: false,
       public_password: null,
       permission: 'canEdit',
+      workspace_sharing: null,
+      workspace_member_count: null,
     };
 
     const result = MetricSchema.safeParse(metricWithCustomConfig);
@@ -277,6 +283,8 @@ describe('MetricSchema', () => {
       publicly_accessible: true,
       public_password: 'secret123',
       permission: 'canEdit',
+      workspace_sharing: null,
+      workspace_member_count: null,
     };
 
     const result = MetricSchema.safeParse(metricWithPartialConfig);
@@ -349,6 +357,8 @@ describe('MetricSchema', () => {
       publicly_accessible: false,
       public_password: null, // nullable
       permission: 'canView',
+      workspace_sharing: null,
+      workspace_member_count: null,
     };
 
     const result = MetricSchema.safeParse(metricWithNulls);

--- a/packages/server-shared/src/share/share-interfaces.test.ts
+++ b/packages/server-shared/src/share/share-interfaces.test.ts
@@ -8,7 +8,7 @@ import {
 
 describe('ShareRoleSchema', () => {
   it('should accept valid role values', () => {
-    const validRoles = ['owner', 'fullAccess', 'canEdit', 'canFilter', 'canView'];
+    const validRoles = ['owner', 'fullAccess', 'canEdit', 'canView'];
 
     for (const role of validRoles) {
       const result = ShareRoleSchema.safeParse(role);
@@ -148,7 +148,7 @@ describe('ShareIndividualSchema', () => {
   });
 
   it('should handle all valid role combinations', () => {
-    const validRoles = ['owner', 'fullAccess', 'canEdit', 'canFilter', 'canView'];
+    const validRoles = ['owner', 'fullAccess', 'canEdit', 'canView'];
 
     for (const role of validRoles) {
       const individual = {
@@ -185,6 +185,8 @@ describe('ShareConfigSchema', () => {
       publicly_accessible: true,
       public_password: 'secretPassword123',
       permission: 'owner',
+      workspace_sharing: null,
+      workspace_member_count: null,
     };
 
     const result = ShareConfigSchema.safeParse(validConfig);
@@ -207,6 +209,8 @@ describe('ShareConfigSchema', () => {
       publicly_accessible: false,
       public_password: null,
       permission: 'canView',
+      workspace_sharing: null,
+      workspace_member_count: null,
     };
 
     const result = ShareConfigSchema.safeParse(configWithNullPermissions);
@@ -230,6 +234,8 @@ describe('ShareConfigSchema', () => {
       publicly_accessible: true,
       public_password: null,
       permission: 'fullAccess',
+      workspace_sharing: null,
+      workspace_member_count: null,
     };
 
     const result = ShareConfigSchema.safeParse(configWithEmptyPermissions);
@@ -243,7 +249,7 @@ describe('ShareConfigSchema', () => {
   });
 
   it('should validate all permission field values', () => {
-    const validPermissions = ['owner', 'fullAccess', 'canEdit', 'canFilter', 'canView'];
+    const validPermissions = ['owner', 'fullAccess', 'canEdit', 'canView'];
 
     for (const permission of validPermissions) {
       const config = {
@@ -253,6 +259,8 @@ describe('ShareConfigSchema', () => {
         publicly_accessible: false,
         public_password: null,
         permission,
+        workspace_sharing: null,
+        workspace_member_count: null,
       };
 
       const result = ShareConfigSchema.safeParse(config);
@@ -274,6 +282,8 @@ describe('ShareConfigSchema', () => {
         publicly_accessible: false,
         public_password: null,
         permission,
+        workspace_sharing: null,
+        workspace_member_count: null,
       };
 
       const result = ShareConfigSchema.safeParse(config);
@@ -290,6 +300,8 @@ describe('ShareConfigSchema', () => {
         publicly_accessible: false,
         public_password: null,
         permission: 'owner',
+        workspace_sharing: null,
+        workspace_member_count: null,
       },
       {
         individual_permissions: null,
@@ -298,6 +310,8 @@ describe('ShareConfigSchema', () => {
         publicly_accessible: false,
         public_password: null,
         permission: 'owner',
+        workspace_sharing: null,
+        workspace_member_count: null,
       },
       {
         individual_permissions: null,
@@ -328,6 +342,8 @@ describe('ShareConfigSchema', () => {
       publicly_accessible: false,
       public_password: null,
       permission: 'owner',
+      workspace_sharing: null,
+      workspace_member_count: null,
     };
 
     const result = ShareConfigSchema.safeParse(configWithInvalidIndividual);
@@ -353,28 +369,24 @@ describe('ShareConfigSchema', () => {
           role: 'canView',
           // name is optional
         },
-        {
-          email: 'filter@company.com',
-          role: 'canFilter',
-          name: 'Filter User',
-        },
       ],
       public_expiry_date: '2024-06-30T23:59:59Z',
       public_enabled_by: 'admin@company.com',
       publicly_accessible: true,
       public_password: 'complex_password_123!',
       permission: 'fullAccess',
+      workspace_sharing: null,
+      workspace_member_count: null,
     };
 
     const result = ShareConfigSchema.safeParse(complexConfig);
     expect(result.success).toBe(true);
 
     if (result.success) {
-      expect(result.data.individual_permissions).toHaveLength(4);
+      expect(result.data.individual_permissions).toHaveLength(3);
       expect(result.data.individual_permissions?.[0]?.role).toBe('owner');
       expect(result.data.individual_permissions?.[1]?.role).toBe('canEdit');
       expect(result.data.individual_permissions?.[2]?.role).toBe('canView');
-      expect(result.data.individual_permissions?.[3]?.role).toBe('canFilter');
       expect(result.data.individual_permissions?.[2]?.name).toBeUndefined();
     }
   });
@@ -387,6 +399,8 @@ describe('ShareConfigSchema', () => {
       publicly_accessible: true,
       public_password: null,
       permission: 'owner',
+      workspace_sharing: null,
+      workspace_member_count: null,
     };
 
     const privateConfig = {
@@ -396,6 +410,8 @@ describe('ShareConfigSchema', () => {
       publicly_accessible: false,
       public_password: null,
       permission: 'owner',
+      workspace_sharing: null,
+      workspace_member_count: null,
     };
 
     const publicResult = ShareConfigSchema.safeParse(publicConfig);


### PR DESCRIPTION
## Summary
- Fixed failing unit tests in the `server-shared` package by adding missing `workspace_sharing` and `workspace_member_count` fields to test objects
- Updated Slack handler tests in `apps/server` to expect absolute URLs with the `http://localhost:3000` prefix
- Removed references to non-existent 'canFilter' role from share interface tests

## Changes Made
1. **server-shared/src/metrics/metric.types.test.ts**
   - Added `workspace_sharing: null` and `workspace_member_count: null` to all metric test objects

2. **server-shared/src/share/share-interfaces.test.ts**
   - Added missing `workspace_sharing` and `workspace_member_count` fields to ShareConfig test objects
   - Removed 'canFilter' from valid roles (it doesn't exist in the ShareRoleSchema)
   - Updated test expectations to match the actual number of valid roles

3. **apps/server/src/api/v2/slack/handler.test.ts**
   - Updated redirect URL expectations to include the full URL with `http://localhost:3000` prefix

## Test Results
All unit tests are now passing across the monorepo.

🤖 Generated with [Claude Code](https://claude.ai/code)