### PR TITLE
Enhance task triggering by adding concurrency key for sequential processing

### DIFF
--- a/apps/server/src/api/v2/chats/handler.test.ts
+++ b/apps/server/src/api/v2/chats/handler.test.ts
@@ -108,9 +108,15 @@ describe('createChatHandler', () => {
       mockUser,
       '550e8400-e29b-41d4-a716-446655440000'
     );
-    expect(tasks.trigger).toHaveBeenCalledWith('analyst-agent-task', {
-      message_id: 'msg-123',
-    });
+    expect(tasks.trigger).toHaveBeenCalledWith(
+      'analyst-agent-task',
+      {
+        message_id: 'msg-123',
+      },
+      {
+        concurrencyKey: 'chat-123',
+      }
+    );
     expect(result).toEqual(mockChat);
   });
 
@@ -131,9 +137,15 @@ describe('createChatHandler', () => {
       mockUser,
       mockChat
     );
-    expect(tasks.trigger).toHaveBeenCalledWith('analyst-agent-task', {
-      message_id: 'msg-123',
-    });
+    expect(tasks.trigger).toHaveBeenCalledWith(
+      'analyst-agent-task',
+      {
+        message_id: 'msg-123',
+      },
+      {
+        concurrencyKey: 'chat-123',
+      }
+    );
     expect(result).toEqual(assetChat);
   });
 
@@ -153,9 +165,15 @@ describe('createChatHandler', () => {
     );
 
     expect(handleAssetChat).not.toHaveBeenCalled();
-    expect(tasks.trigger).toHaveBeenCalledWith('analyst-agent-task', {
-      message_id: 'msg-123',
-    });
+    expect(tasks.trigger).toHaveBeenCalledWith(
+      'analyst-agent-task',
+      {
+        message_id: 'msg-123',
+      },
+      {
+        concurrencyKey: 'chat-123',
+      }
+    );
     expect(result).toEqual(mockChat);
   });
 

--- a/apps/server/src/api/v2/chats/handler.ts
+++ b/apps/server/src/api/v2/chats/handler.ts
@@ -77,9 +77,15 @@ export async function createChatHandler(
     if (request.prompt || request.asset_id) {
       try {
         // Just queue the background job - should be <100ms
-        const taskHandle = await tasks.trigger('analyst-agent-task', {
-          message_id: messageId,
-        });
+        const taskHandle = await tasks.trigger(
+          'analyst-agent-task',
+          {
+            message_id: messageId,
+          },
+          {
+            concurrencyKey: chatId, // Ensure sequential processing per chat
+          }
+        );
 
         // Health check: Verify trigger service received the task
         // The presence of taskHandle.id confirms Trigger.dev accepted our request

--- a/apps/trigger/src/queues/analyst-queue.ts
+++ b/apps/trigger/src/queues/analyst-queue.ts
@@ -1,0 +1,14 @@
+import { queue } from '@trigger.dev/sdk';
+
+/**
+ * Queue configuration for analyst agent tasks.
+ * This queue ensures that only one analyst task runs at a time per chat,
+ * while allowing multiple chats to process concurrently.
+ *
+ * Usage: When triggering analyst-agent-task, use concurrencyKey with the chatId
+ * to create separate queue instances for each chat.
+ */
+export const analystQueue: ReturnType<typeof queue> = queue({
+  name: 'analyst-agent-queue',
+  concurrencyLimit: 1, // Only 1 task runs at a time per concurrencyKey (chatId)
+});

--- a/apps/trigger/src/tasks/analyst-agent-task/analyst-agent-task.ts
+++ b/apps/trigger/src/tasks/analyst-agent-task/analyst-agent-task.ts
@@ -1,5 +1,6 @@
 import { logger, schemaTask, tasks } from '@trigger.dev/sdk';
 import { currentSpan, initLogger, wrapTraced } from 'braintrust';
+import { analystQueue } from '../../queues/analyst-queue';
 import { AnalystAgentTaskInputSchema, type AnalystAgentTaskOutput } from './types';
 
 // Task 2 & 4: Database helpers (IMPLEMENTED)
@@ -276,6 +277,7 @@ export const analystAgentTask: ReturnType<
   id: 'analyst-agent-task',
   machine: 'small-2x',
   schema: AnalystAgentTaskInputSchema,
+  queue: analystQueue,
   maxDuration: 600, // 10 minutes for complex analysis
   run: async (payload): Promise<AnalystAgentTaskOutput> => {
     const taskStartTime = Date.now();


### PR DESCRIPTION
- Updated `createChatHandler` to include a `concurrencyKey` when triggering the `analyst-agent-task`, ensuring tasks are processed sequentially per chat.
- Adjusted related test cases to verify the inclusion of the `concurrencyKey`.
- Integrated the `concurrencyKey` in the `slackAgentTask` to manage task queuing and notify users when tasks are queued.