### PR TITLE
Add fetch body modification for tool_choice in Anthropics and Vertex models

### DIFF
--- a/packages/ai/src/utils/models/providers/anthropic.ts
+++ b/packages/ai/src/utils/models/providers/anthropic.ts
@@ -6,6 +6,40 @@ export const anthropicModel = (modelId: string) => {
     headers: {
       'anthropic-beta': 'fine-grained-tool-streaming-2025-05-14',
     },
+    fetch: ((url, options) => {
+      if (options?.body) {
+        try {
+          // Parse existing body if it's a string
+          const existingBody =
+            typeof options.body === 'string' ? JSON.parse(options.body) : options.body;
+
+          // Append disable_parallel_tool_use if tool_choice is present
+          const modifiedBody = {
+            ...existingBody,
+          };
+
+          if (modifiedBody.tool_choice) {
+            modifiedBody.tool_choice = {
+              ...modifiedBody.tool_choice,
+              disable_parallel_tool_use: true,
+            };
+          }
+
+          // Return modified options
+          return fetch(url, {
+            ...options,
+            body: JSON.stringify(modifiedBody),
+          });
+        } catch (error) {
+          console.error('Failed to parse request body:', error);
+          // If body parsing fails, fall back to original request
+          return fetch(url, options);
+        }
+      }
+
+      // For requests without body, pass through unchanged
+      return fetch(url, options);
+    }) as typeof fetch,
   });
 
   // Wrap the model with Braintrust tracing and return it

--- a/packages/ai/src/utils/models/providers/vertex.ts
+++ b/packages/ai/src/utils/models/providers/vertex.ts
@@ -34,6 +34,40 @@ export const vertexModel = (modelId: string): LanguageModelV1 => {
         headers: {
           'anthropic-beta': 'fine-grained-tool-streaming-2025-05-14',
         },
+        fetch: ((url, options) => {
+          if (options?.body) {
+            try {
+              // Parse existing body if it's a string
+              const existingBody =
+                typeof options.body === 'string' ? JSON.parse(options.body) : options.body;
+
+              // Append disable_parallel_tool_use if tool_choice is present
+              const modifiedBody = {
+                ...existingBody,
+              };
+
+              if (modifiedBody.tool_choice) {
+                modifiedBody.tool_choice = {
+                  ...modifiedBody.tool_choice,
+                  disable_parallel_tool_use: true,
+                };
+              }
+
+              // Return modified options
+              return fetch(url, {
+                ...options,
+                body: JSON.stringify(modifiedBody),
+              });
+            } catch (error) {
+              console.error('Failed to parse request body:', error);
+              // If body parsing fails, fall back to original request
+              return fetch(url, options);
+            }
+          }
+
+          // For requests without body, pass through unchanged
+          return fetch(url, options);
+        }) as typeof fetch,
       });
 
       // Wrap the model with Braintrust tracing


### PR DESCRIPTION
- Implemented a custom fetch function in both anthropic.ts and vertex.ts to modify the request body.
- If tool_choice is present, added disable_parallel_tool_use to the request body.
- Included error handling for JSON parsing to ensure fallback to original request on failure.