### PR TITLE
Remove react.memo from components accepting children

### DIFF
--- a/apps/web/src/app/app/(primary_layout)/datasets/[datasetId]/permissions/PermissionsAppContainer.tsx
+++ b/apps/web/src/app/app/(primary_layout)/datasets/[datasetId]/permissions/PermissionsAppContainer.tsx
@@ -16,7 +16,7 @@ const routeToApp: Record<string, PermissionApps> = {
 
 export const PermissionsAppContainer: React.FC<{
   children: React.ReactNode;
-}> = React.memo(({ children }) => {
+}> = ({ children }) => {
   const { datasetId } = useParams();
   const currentRoute = useAppLayoutContextSelector((x) => x.currentRoute);
   const [selectedApp, setSelectedApp] = useState<PermissionApps>(PermissionApps.OVERVIEW);
@@ -32,6 +32,6 @@ export const PermissionsAppContainer: React.FC<{
       {children}
     </>
   );
-});
+};
 
 PermissionsAppContainer.displayName = 'PermissionsAppContainer';

--- a/apps/web/src/components/features/PermissionComponents/PermissionAssignTeamRole.tsx
+++ b/apps/web/src/components/features/PermissionComponents/PermissionAssignTeamRole.tsx
@@ -22,7 +22,7 @@ export const PermissionAssignTeamRole: React.FC<{
   id: string;
   onRoleChange: (data: { id: string; role: TeamRole }) => void;
   children?: React.ReactNode;
-}> = React.memo(({ role, id, onRoleChange, children }) => {
+}> = ({ role, id, onRoleChange, children }) => {
   return (
     <div
       className="flex items-center space-x-5"
@@ -40,6 +40,6 @@ export const PermissionAssignTeamRole: React.FC<{
       />
     </div>
   );
-});
+};
 
 PermissionAssignTeamRole.displayName = 'PermissionAssignTeamRole';

--- a/apps/web/src/components/features/PermissionComponents/PermissionAssignedCell.tsx
+++ b/apps/web/src/components/features/PermissionComponents/PermissionAssignedCell.tsx
@@ -29,7 +29,7 @@ export const PermissionAssignedCell: React.FC<{
   assigned: boolean;
   onSelect: (params: { id: string; assigned: boolean }) => Promise<void>;
   children?: React.ReactNode;
-}> = React.memo(({ id, text = 'included', assigned, onSelect, children }) => {
+}> = ({ id, text = 'included', assigned, onSelect, children }) => {
   const assignedValue = assigned ? 'true' : 'false';
 
   return (
@@ -50,6 +50,6 @@ export const PermissionAssignedCell: React.FC<{
       />
     </div>
   );
-});
+};
 
 PermissionAssignedCell.displayName = 'PermissionAssignedCell';

--- a/apps/web/src/components/features/ShareMenu/ShareMenu.tsx
+++ b/apps/web/src/components/features/ShareMenu/ShareMenu.tsx
@@ -14,7 +14,7 @@ export const ShareMenu: React.FC<
     assetId: string;
     assetType: ShareAssetType;
   }>
-> = React.memo(({ children, shareAssetConfig, assetId, assetType }) => {
+> = ({ children, shareAssetConfig, assetId, assetType }) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const onOpenChange = useMemoizedFn((v: boolean) => {
@@ -47,5 +47,5 @@ export const ShareMenu: React.FC<
       </AppTooltip>
     </Popover>
   );
-});
+};
 ShareMenu.displayName = 'ShareMenu';

--- a/apps/web/src/components/features/colors/DefaultThemeSelector/EditCustomThemeMenu.tsx
+++ b/apps/web/src/components/features/colors/DefaultThemeSelector/EditCustomThemeMenu.tsx
@@ -5,7 +5,7 @@ import { NewThemePopup } from './NewThemePopup';
 import { useAddTheme } from './AddThemeProviderWrapper';
 
 export const EditCustomThemeMenu: React.FC<PropsWithChildren<{ theme: IColorPalette }>> =
-  React.memo(({ theme, children }) => {
+  ({ theme, children }) => {
     const { deleteCustomTheme, modifyCustomTheme } = useAddTheme();
 
     const onSave = useMemoizedFn((theme: IColorPalette) => {
@@ -25,6 +25,6 @@ export const EditCustomThemeMenu: React.FC<PropsWithChildren<{ theme: IColorPale
         {children}
       </NewThemePopup>
     );
-  });
+  };
 
 EditCustomThemeMenu.displayName = 'EditCustomThemeMenu';

--- a/apps/web/src/components/features/dropdowns/SaveToCollectionsDropdown.tsx
+++ b/apps/web/src/components/features/dropdowns/SaveToCollectionsDropdown.tsx
@@ -14,7 +14,7 @@ export const SaveToCollectionsDropdown: React.FC<{
   selectedCollections: string[];
   onSaveToCollection: (collectionId: string[]) => Promise<void>;
   onRemoveFromCollection: (collectionId: string) => Promise<void>;
-}> = React.memo(({ children, onRemoveFromCollection, onSaveToCollection, selectedCollections }) => {
+}> = ({ children, onRemoveFromCollection, onSaveToCollection, selectedCollections }) => {
   const { ModalComponent, selectType, footerContent, menuHeader, items } =
     useSaveToCollectionsDropdownContent({
       selectedCollections,
@@ -38,7 +38,7 @@ export const SaveToCollectionsDropdown: React.FC<{
       {ModalComponent}
     </>
   );
-});
+};
 
 SaveToCollectionsDropdown.displayName = 'SaveToCollectionsDropdown';
 

--- a/apps/web/src/components/features/metrics/StatusBadgeIndicator/StatusDropdownContent.tsx
+++ b/apps/web/src/components/features/metrics/StatusBadgeIndicator/StatusDropdownContent.tsx
@@ -9,7 +9,7 @@ export const StatusDropdownContent: React.FC<{
   children: React.ReactNode;
   onChangeStatus: (status: VerificationStatus) => void;
   onOpenChange?: (open: boolean) => void;
-}> = React.memo(({ isAdmin, status, onChangeStatus, children, onOpenChange }) => {
+}> = ({ isAdmin, status, onChangeStatus, children, onOpenChange }) => {
   const dropdownProps = useStatusDropdownContent({
     isAdmin,
     selectedStatus: status,
@@ -23,5 +23,5 @@ export const StatusDropdownContent: React.FC<{
       {children}
     </Dropdown>
   );
-});
+};
 StatusDropdownContent.displayName = 'StatusDropdownContent';

--- a/apps/web/src/components/features/modal/NewDatasetModal.tsx
+++ b/apps/web/src/components/features/modal/NewDatasetModal.tsx
@@ -168,7 +168,7 @@ DatasetNameInput.displayName = 'DatasetNameInput';
 const FormWrapper: React.FC<{
   title: string;
   children: React.ReactNode;
-}> = React.memo(({ title, children }) => {
+}> = ({ title, children }) => {
   return (
     <div className="grid grid-cols-[minmax(150px,auto)_1fr] gap-4">
       <div>
@@ -177,5 +177,5 @@ const FormWrapper: React.FC<{
       <div>{children}</div>
     </div>
   );
-});
+};
 FormWrapper.displayName = 'FormWrapper';

--- a/apps/web/src/components/features/sidebars/SidebarUserFooter/SidebarUserFooter.tsx
+++ b/apps/web/src/components/features/sidebars/SidebarUserFooter/SidebarUserFooter.tsx
@@ -86,7 +86,7 @@ const topItems: DropdownProps['items'] = [
 const SidebarUserDropdown: React.FC<{
   children: React.ReactNode;
   signOut: () => void;
-}> = React.memo(({ children, signOut }) => {
+}> = ({ children, signOut }) => {
   const onOpenContactSupportModal = useContactSupportModalStore((s) => s.onOpenContactSupportModal);
 
   const allItems: DropdownProps['items'] = useMemo(() => {
@@ -127,6 +127,6 @@ const SidebarUserDropdown: React.FC<{
       {children}
     </Dropdown>
   );
-});
+};
 
 SidebarUserDropdown.displayName = 'SidebarUserDropdown';

--- a/apps/web/src/components/ui/grid/_BusterSortableItemDragContainer.tsx
+++ b/apps/web/src/components/ui/grid/_BusterSortableItemDragContainer.tsx
@@ -8,7 +8,7 @@ export const BusterSortableItemDragContainer: React.FC<{
   itemId: string;
   allowEdit?: boolean;
   children: React.ReactNode;
-}> = React.memo(({ itemId, allowEdit = true, children }) => {
+}> = ({ itemId, allowEdit = true, children }) => {
   const {
     attributes,
     isDragging,
@@ -55,6 +55,6 @@ export const BusterSortableItemDragContainer: React.FC<{
       </BusterSortableItemContent>
     </SortableItemContext.Provider>
   );
-});
+};
 
 BusterSortableItemDragContainer.displayName = 'BusterSortableItemDragContainer';

--- a/apps/web/src/components/ui/list/InfiniteListContainer/InfiniteListContainer.tsx
+++ b/apps/web/src/components/ui/list/InfiniteListContainer/InfiniteListContainer.tsx
@@ -5,7 +5,7 @@ export const InfiniteListContainer: React.FC<{
   children: React.ReactNode;
   popupNode?: React.ReactNode;
   showContainerBorder?: boolean;
-}> = React.memo(({ children, popupNode, showContainerBorder = true }) => {
+}> = ({ children, popupNode, showContainerBorder = true }) => {
   return (
     <div className={cn('overflow-hidden', showContainerBorder && 'border-border rounded border')}>
       {children}
@@ -17,6 +17,6 @@ export const InfiniteListContainer: React.FC<{
       )}
     </div>
   );
-});
+};
 
 InfiniteListContainer.displayName = 'InfiniteListContainer';

--- a/apps/web/src/components/ui/table/AppDataGrid/TanStackDataGrid/SortColumnWrapper.tsx
+++ b/apps/web/src/components/ui/table/AppDataGrid/TanStackDataGrid/SortColumnWrapper.tsx
@@ -31,7 +31,7 @@ export const SortColumnWrapper: React.FC<{
   colOrder: string[];
   setColOrder: (colOrder: string[]) => void;
   onReorderColumns?: ((columnIds: string[]) => void) | undefined;
-}> = React.memo(({ table, draggable, children, colOrder, setColOrder, onReorderColumns }) => {
+}> = ({ table, draggable, children, colOrder, setColOrder, onReorderColumns }) => {
   // Track active drag item and over target
   const [activeId, setActiveId] = useState<string | null>(null);
   const [overTargetId, setOverTargetId] = useState<string | null>(null);
@@ -153,7 +153,7 @@ export const SortColumnWrapper: React.FC<{
       </SortColumnContext.Provider>
     </DndContext>
   );
-});
+};
 
 SortColumnWrapper.displayName = 'SortColumnWrapper';
 

--- a/apps/web/src/components/ui/tooltip/Tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip/Tooltip.tsx
@@ -20,49 +20,44 @@ export interface TooltipProps
   contentClassName?: string;
 }
 
-export const Tooltip = React.memo(
-  React.forwardRef<HTMLSpanElement, TooltipProps>(
-    (
-      {
-        children,
-        title,
-        sideOffset,
-        shortcuts,
-        delayDuration = 0,
-        skipDelayDuration,
-        align,
-        side,
-        open,
-        triggerClassName,
-        contentClassName
-      },
-      ref
-    ) => {
-      if (!title || (!title && !shortcuts?.length)) return children;
+export const Tooltip = React.forwardRef<HTMLSpanElement, TooltipProps>(
+  (
+    {
+      children,
+      title,
+      sideOffset,
+      shortcuts,
+      delayDuration = 0,
+      skipDelayDuration,
+      align,
+      side,
+      open,
+      triggerClassName,
+      contentClassName
+    },
+    ref
+  ) => {
+    if (!title || (!title && !shortcuts?.length)) return children;
 
-      return (
-        <TooltipBase
-          open={open}
-          delayDuration={delayDuration}
-          skipDelayDuration={skipDelayDuration}>
-          <TooltipTrigger asChild>
-            <span ref={ref} className={triggerClassName}>
-              {children}
-            </span>
-          </TooltipTrigger>
-          <TooltipContentBase
-            align={align}
-            side={side}
-            sideOffset={sideOffset}
-            className={contentClassName}>
-            <TooltipContent title={title} shortcut={shortcuts} />
-          </TooltipContentBase>
-        </TooltipBase>
-      );
-    }
-  ),
-  (prevProps, nextProps) => {
-    return omit(prevProps, 'shortcut') === omit(nextProps, 'shortcut');
+    return (
+      <TooltipBase
+        open={open}
+        delayDuration={delayDuration}
+        skipDelayDuration={skipDelayDuration}>
+        <TooltipTrigger asChild>
+          <span ref={ref} className={triggerClassName}>
+            {children}
+          </span>
+        </TooltipTrigger>
+        <TooltipContentBase
+          align={align}
+          side={side}
+          sideOffset={sideOffset}
+          className={contentClassName}>
+          <TooltipContent title={title} shortcut={shortcuts} />
+        </TooltipContentBase>
+      </TooltipBase>
+    );
   }
 );
 

--- a/apps/web/src/components/ui/typography/EditableTitle.tsx
+++ b/apps/web/src/components/ui/typography/EditableTitle.tsx
@@ -20,84 +20,82 @@ const editableTitleVariants = cva('relative flex items-center justify-between', 
   }
 });
 
-export const EditableTitle = React.memo(
-  React.forwardRef<
-    HTMLInputElement,
+export const EditableTitle = React.forwardRef<
+  HTMLInputElement,
+  {
+    children: string;
+    onEdit?: (b: boolean) => void;
+    onChange: (value: string) => void;
+    onSetValue?: (value: string) => void;
+    onPressEnter?: () => void;
+    disabled?: boolean;
+    className?: string;
+    placeholder?: string;
+    style?: React.CSSProperties;
+    inputClassName?: string;
+    id?: string;
+    readOnly?: boolean;
+  } & VariantProps<typeof editableTitleVariants>
+>(
+  (
     {
-      children: string;
-      onEdit?: (b: boolean) => void;
-      onChange: (value: string) => void;
-      onSetValue?: (value: string) => void;
-      onPressEnter?: () => void;
-      disabled?: boolean;
-      className?: string;
-      placeholder?: string;
-      style?: React.CSSProperties;
-      inputClassName?: string;
-      id?: string;
-      readOnly?: boolean;
-    } & VariantProps<typeof editableTitleVariants>
-  >(
-    (
-      {
-        id,
-        readOnly,
-        style,
-        disabled,
-        className = '',
-        inputClassName = '',
-        placeholder,
-        onPressEnter,
-        children,
-        level = 4,
-        onEdit,
-        onChange,
-        onSetValue
-      },
-      inputRef
-    ) => {
-      const [value, setValue] = React.useState(children);
+      id,
+      readOnly,
+      style,
+      disabled,
+      className = '',
+      inputClassName = '',
+      placeholder,
+      onPressEnter,
+      children,
+      level = 4,
+      onEdit,
+      onChange,
+      onSetValue
+    },
+    inputRef
+  ) => {
+    const [value, setValue] = React.useState(children);
 
-      useLayoutEffect(() => {
-        setValue(children);
-      }, [children]);
+    useLayoutEffect(() => {
+      setValue(children);
+    }, [children]);
 
-      return (
-        <div className={cn('relative flex items-center justify-between', className)} style={style}>
-          <Input
-            placeholder={placeholder}
-            ref={inputRef}
-            id={id}
-            disabled={disabled}
-            readOnly={readOnly}
-            variant="ghost"
-            className={cn(
-              'w-full cursor-text! rounded-none! px-0! py-0! leading-1',
-              editableTitleVariants({ level }),
-              inputClassName
-            )}
-            value={value}
-            onChange={(e) => {
-              if (e.target.value !== value) setValue(e.target.value);
-              onSetValue?.(e.target.value);
-            }}
-            onBlur={() => {
-              onChange(value);
-              onEdit?.(false);
-            }}
-            onFocus={() => {
-              onEdit?.(true);
-            }}
-            onPressEnter={() => {
-              onChange(value);
-              onPressEnter?.();
-            }}
-          />
-          <div className="from-page-background pointer-events-none absolute top-0 right-0 h-full w-6 bg-gradient-to-l to-transparent" />
-        </div>
-      );
-    }
-  )
+    return (
+      <div className={cn('relative flex items-center justify-between', className)} style={style}>
+        <Input
+          placeholder={placeholder}
+          ref={inputRef}
+          id={id}
+          disabled={disabled}
+          readOnly={readOnly}
+          variant="ghost"
+          className={cn(
+            'w-full cursor-text! rounded-none! px-0! py-0! leading-1',
+            editableTitleVariants({ level }),
+            inputClassName
+          )}
+          value={value}
+          onChange={(e) => {
+            if (e.target.value !== value) setValue(e.target.value);
+            onSetValue?.(e.target.value);
+          }}
+          onBlur={() => {
+            onChange(value);
+            onEdit?.(false);
+          }}
+          onFocus={() => {
+            onEdit?.(true);
+          }}
+          onPressEnter={() => {
+            onChange(value);
+            onPressEnter?.();
+          }}
+        />
+        <div className="from-page-background pointer-events-none absolute top-0 right-0 h-full w-6 bg-gradient-to-l to-transparent" />
+      </div>
+    );
+  }
 );
 
 EditableTitle.displayName = 'EditableTitle';

--- a/apps/web/src/components/ui/typography/SyntaxHighlight/SyntaxHighlighter.tsx
+++ b/apps/web/src/components/ui/typography/SyntaxHighlight/SyntaxHighlighter.tsx
@@ -8,7 +8,7 @@ import { animations, type MarkdownAnimation } from '../animation-common';
 import type { ThemedToken } from 'shiki';
 import { useCodeTokens } from './useCodeTokens';
 
-export const SyntaxHighlighter = React.memo(
+export const SyntaxHighlighter = (
   ({
     children,
     language = 'sql',

--- a/apps/web/src/context/BusterWebSocket/BusterWebSocketProvider/useBusterWebSocket.tsx
+++ b/apps/web/src/context/BusterWebSocket/BusterWebSocketProvider/useBusterWebSocket.tsx
@@ -200,7 +200,7 @@ const BusterWebSocket = createContext<ReturnType<typeof useBusterWebSocketHook>>
 
 export const BusterWebSocketProvider: React.FC<{
   children: React.ReactNode;
-}> = React.memo(({ children }) => {
+}> = ({ children }) => {
   const accessToken = useSupabaseContext((state) => state.accessToken);
   const isAnonymousUser = useSupabaseContext((x) => x.isAnonymousUser);
   const checkTokenValidity = useSupabaseContext((state) => state.checkTokenValidity);
@@ -212,7 +212,7 @@ export const BusterWebSocketProvider: React.FC<{
   });
 
   return <BusterWebSocket.Provider value={busterSocketHook}>{children}</BusterWebSocket.Provider>;
-});
+};
 BusterWebSocketProvider.displayName = 'BusterWebSocketProvider';
 
 const useBusterWebSocketSelector = <T,>(

--- a/apps/web/src/context/Posthog/BusterPosthogProvider.tsx
+++ b/apps/web/src/context/Posthog/BusterPosthogProvider.tsx
@@ -12,13 +12,13 @@ import type { Team } from '@buster/server-shared/teams';
 const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 const DEBUG_POSTHOG = false;
 
-export const BusterPosthogProvider: React.FC<PropsWithChildren> = React.memo(({ children }) => {
+export const BusterPosthogProvider: React.FC<PropsWithChildren> = ({ children }) => {
   if ((isDev && !DEBUG_POSTHOG) || !POSTHOG_KEY) {
     return <>{children}</>;
   }
 
   return <PosthogWrapper>{children}</PosthogWrapper>;
-});
+};
 BusterPosthogProvider.displayName = 'BusterPosthogProvider';
 
 const options: Partial<PostHogConfig> = {

--- a/apps/web/src/context/Supabase/SupabaseContextProvider.tsx
+++ b/apps/web/src/context/Supabase/SupabaseContextProvider.tsx
@@ -139,11 +139,11 @@ export const SupabaseContextProvider: React.FC<
   PropsWithChildren<{
     supabaseContext: UseSupabaseUserContextType;
   }>
-> = React.memo(({ supabaseContext, children }) => {
+> = ({ supabaseContext, children }) => {
   const value = useSupabaseContextInternal({ supabaseContext });
 
   return <SupabaseContext.Provider value={value}>{children}</SupabaseContext.Provider>;
-});
+};
 SupabaseContextProvider.displayName = 'SupabaseContextProvider';
 
 export type SupabaseContextReturnType = ReturnType<typeof useSupabaseContextInternal>;

--- a/apps/web/src/controllers/AppPasswordAccess.tsx
+++ b/apps/web/src/controllers/AppPasswordAccess.tsx
@@ -13,7 +13,7 @@ export const AppPasswordAccess: React.FC<{
   assetId: string;
   type: ShareAssetType;
   children: React.ReactNode;
-}> = React.memo(({ children, assetId, type }) => {
+}> = ({ children, assetId, type }) => {
   const getAssetPassword = useBusterAssetsContextSelector((state) => state.getAssetPassword);
   const { password, error } = getAssetPassword(assetId);
 
@@ -24,7 +24,7 @@ export const AppPasswordAccess: React.FC<{
   return (
     <AppPasswordInputComponent password={password} error={error} assetId={assetId} type={type} />
   );
-});
+};
 
 AppPasswordAccess.displayName = 'AppPasswordAccess';
 

--- a/apps/web/src/controllers/MetricController/MetricViewChart/MetricViewChart.tsx
+++ b/apps/web/src/controllers/MetricController/MetricViewChart/MetricViewChart.tsx
@@ -135,7 +135,7 @@ const MetricViewChartCard: React.FC<{
   errorData: boolean;
   isTable: boolean;
   className?: string;
-}> = React.memo(({ children, loadingData, hasData, errorData, isTable, className }) => {
+}> = ({ children, loadingData, hasData, errorData, isTable, className }) => {
   const cardClass = useMemo(() => {
     if (loadingData || errorData || !hasData) return 'h-full max-h-[600px]';
     if (isTable) return '';
@@ -152,7 +152,7 @@ const MetricViewChartCard: React.FC<{
       {children}
     </div>
   );
-});
+};
 
 MetricViewChartCard.displayName = 'MetricViewChartCard';
 

--- a/apps/web/src/controllers/ReasoningController/ReasoningMessages/BarContainer.tsx
+++ b/apps/web/src/controllers/ReasoningController/ReasoningMessages/BarContainer.tsx
@@ -12,7 +12,7 @@ export const BarContainer: React.FC<{
   children?: React.ReactNode;
   title: string;
   secondaryTitle?: string;
-}> = React.memo(({ showBar, isStreamFinished, status, children, title, secondaryTitle }) => {
+}> = ({ showBar, isStreamFinished, status, children, title, secondaryTitle }) => {
   return (
     <div className={'relative flex space-x-1.5 overflow-visible'}>
       <VerticalBarContainer showBar={showBar} status={status} isStreamFinished={isStreamFinished} />
@@ -27,7 +27,7 @@ export const BarContainer: React.FC<{
       </div>
     </div>
   );
-});
+};
 
 BarContainer.displayName = 'BarContainer';
 

--- a/apps/web/src/layouts/AppAssetCheckLayout/AppAssetCheckLayout.tsx
+++ b/apps/web/src/layouts/AppAssetCheckLayout/AppAssetCheckLayout.tsx
@@ -19,7 +19,7 @@ export const AppAssetCheckLayout: React.FC<
   {
     children: React.ReactNode;
   } & AppAssetCheckLayoutProps
-> = React.memo(({ children, type, assetId, versionNumber }) => {
+> = ({ children, type, assetId, versionNumber }) => {
   const {
     hasAccess,
     passwordRequired,
@@ -65,6 +65,6 @@ export const AppAssetCheckLayout: React.FC<
       {Component}
     </>
   );
-});
+};
 
 AppAssetCheckLayout.displayName = 'AppAssetCheckLayout';

--- a/apps/web/src/layouts/ChatLayout/ChatContainer/ChatContent/ChatContent.tsx
+++ b/apps/web/src/layouts/ChatLayout/ChatContainer/ChatContent/ChatContent.tsx
@@ -59,7 +59,7 @@ ChatContent.displayName = 'ChatContent';
 
 const ChatInputWrapper: React.FC<{
   children?: React.ReactNode;
-}> = React.memo(({ children }) => {
+}> = ({ children }) => {
   return (
     <div className="bg-page-background absolute bottom-0 w-full overflow-visible">
       <div className="from-page-background pointer-events-none absolute -top-16 h-16 w-full bg-gradient-to-t to-transparent" />
@@ -69,6 +69,6 @@ const ChatInputWrapper: React.FC<{
       </div>
     </div>
   );
-});
+};
 
 ChatInputWrapper.displayName = 'ChatInputWrapper';

--- a/apps/web/src/layouts/ChatLayout/ChatContainer/ChatHeader/ChatHeaderOptions/ChatHeaderDropdown.tsx
+++ b/apps/web/src/layouts/ChatLayout/ChatContainer/ChatHeader/ChatHeaderOptions/ChatHeaderDropdown.tsx
@@ -15,7 +15,7 @@ import { CHAT_HEADER_TITLE_ID } from '../ChatHeaderTitle';
 
 export const ChatContainerHeaderDropdown: React.FC<{
   children: React.ReactNode;
-}> = React.memo(({ children }) => {
+}> = ({ children }) => {
   const { openSuccessMessage } = useBusterNotifications();
   const chatId = useChatIndividualContextSelector((state) => state.chatId);
   const onChangePage = useAppLayoutContextSelector((s) => s.onChangePage);
@@ -117,6 +117,6 @@ export const ChatContainerHeaderDropdown: React.FC<{
       {chatId ? children : null}
     </Dropdown>
   );
-});
+};
 
 ChatContainerHeaderDropdown.displayName = 'ChatContainerHeaderDropdown';

--- a/apps/web/src/layouts/ChatLayout/ChatContext/ChatContext.tsx
+++ b/apps/web/src/layouts/ChatLayout/ChatContext/ChatContext.tsx
@@ -86,7 +86,7 @@ const IndividualChatContext = createContext<ReturnType<typeof useChatIndividualC
   {} as ReturnType<typeof useChatIndividualContext>
 );
 
-export const ChatContextProvider = React.memo(({ children }: PropsWithChildren) => {
+export const ChatContextProvider = ({ children }: PropsWithChildren) => {
   const chatId = useChatLayoutContextSelector((x) => x.chatId);
   const selectedFile = useChatLayoutContextSelector((x) => x.selectedFile);
 
@@ -100,7 +100,7 @@ export const ChatContextProvider = React.memo(({ children }: PropsWithChildren) 
       {children}
     </IndividualChatContext.Provider>
   );
-});
+};
 
 ChatContextProvider.displayName = 'ChatContextProvider';
 

--- a/apps/web/src/layouts/ChatLayout/ChatLayoutContext/ChatLayoutContext.tsx
+++ b/apps/web/src/layouts/ChatLayout/ChatLayoutContext/ChatLayoutContext.tsx
@@ -85,7 +85,7 @@ type ChatLayoutContextProviderProps = {
   chatLayoutProps: ReturnType<typeof useChatLayoutContext>;
 };
 
-export const ChatLayoutContextProvider: React.FC<ChatLayoutContextProviderProps> = React.memo(
+export const ChatLayoutContextProvider: React.FC<ChatLayoutContextProviderProps> = (
   ({ children, chatLayoutProps }) => {
     return (
       <ChatLayoutContext.Provider value={chatLayoutProps}>{children}</ChatLayoutContext.Provider>

--- a/apps/web/src/layouts/ChatLayout/FileContainer/FileContainerHeader/HideButtonContainer.tsx
+++ b/apps/web/src/layouts/ChatLayout/FileContainer/FileContainerHeader/HideButtonContainer.tsx
@@ -11,12 +11,12 @@ const displayAnimation = {
 export const HideButtonContainer: React.FC<{
   children: React.ReactNode;
   show: boolean;
-}> = React.memo(({ children, show }) => {
+}> = ({ children, show }) => {
   return (
     <AnimatePresence mode="wait" initial={false}>
       {show && <motion.div {...displayAnimation}>{children}</motion.div>}
     </AnimatePresence>
   );
-});
+};
 
 HideButtonContainer.displayName = 'HideButtonContainer';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,10 +308,10 @@ importers:
         version: 49.2.4(platejs@49.2.8(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@platejs/autoformat':
         specifier: 'catalog:'
-        version: 49.0.0(platejs@49.2.8(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 49.0.0(platejs@49.2.8(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@platejs/basic-nodes':
         specifier: 'catalog:'
-        version: 49.0.0(platejs@49.2.8(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 49.0.0(platejs@49.2.8(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@platejs/basic-styles':
         specifier: ^49.0.0
         version: 49.0.0(platejs@49.2.8(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -362,7 +362,7 @@ importers:
         version: 49.2.0(platejs@49.2.8(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@platejs/markdown':
         specifier: 'catalog:'
-        version: 49.2.1(platejs@49.2.8(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+        version: 49.2.1(platejs@49.2.8(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@platejs/math':
         specifier: ^49.0.0
         version: 49.0.0(platejs@49.2.8(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1058,13 +1058,13 @@ importers:
         version: link:../vitest-config
       '@platejs/autoformat':
         specifier: 'catalog:'
-        version: 49.0.0(platejs@49.2.8(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 49.0.0(platejs@49.2.8(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@platejs/basic-nodes':
         specifier: 'catalog:'
-        version: 49.0.0(platejs@49.2.8(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 49.0.0(platejs@49.2.8(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@platejs/markdown':
         specifier: 'catalog:'
-        version: 49.2.1(platejs@49.2.8(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+        version: 49.2.1(platejs@49.2.8(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       platejs:
         specifier: 'catalog:'
         version: 49.2.8(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1))
@@ -16067,7 +16067,7 @@ snapshots:
 
   '@platejs/ai@49.2.4(platejs@49.2.8(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
-      '@platejs/markdown': 49.2.1(platejs@49.2.8(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@platejs/markdown': 49.2.1(platejs@49.2.8(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@platejs/selection': 49.2.4(platejs@49.2.8(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       lodash: 4.17.21
       platejs: 49.2.8(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1))
@@ -16077,14 +16077,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@platejs/autoformat@49.0.0(platejs@49.2.8(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@platejs/autoformat@49.0.0(platejs@49.2.8(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       lodash: 4.17.21
       platejs: 49.2.8(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@platejs/basic-nodes@49.0.0(platejs@49.2.8(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@platejs/basic-nodes@49.0.0(platejs@49.2.8(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       platejs: 49.2.8(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1))
       react: 18.3.1
@@ -16140,7 +16140,7 @@ snapshots:
       html-entities: 2.6.0
       is-hotkey: 0.2.0
       jotai: 2.8.4(@types/react@18.3.23)(react@18.3.1)
-      jotai-optics: 0.4.0(jotai@2.8.4(react@18.3.1))(optics-ts@2.4.1)
+      jotai-optics: 0.4.0(jotai@2.8.4(@types/react@18.3.23)(react@18.3.1))(optics-ts@2.4.1)
       jotai-x: 2.3.3(@types/react@18.3.23)(jotai@2.8.4(@types/react@18.3.23)(react@18.3.1))(react@18.3.1)
       lodash: 4.17.21
       nanoid: 5.1.5
@@ -16151,7 +16151,7 @@ snapshots:
       slate-react: 0.117.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)
       use-deep-compare: 1.3.0(react@18.3.1)
       zustand: 5.0.7(@types/react@18.3.23)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1))
-      zustand-x: 6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(zustand@5.0.7(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1)))
+      zustand-x: 6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(zustand@5.0.7(@types/react@18.3.23)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1)))
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -16242,7 +16242,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@platejs/markdown@49.2.1(platejs@49.2.8(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@platejs/markdown@49.2.1(platejs@49.2.8(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(slate-dom@0.116.0(slate@0.117.0))(slate@0.117.0)(use-sync-external-store@1.5.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
       marked: 15.0.12
       mdast-util-math: 3.0.0
@@ -18560,15 +18560,6 @@ snapshots:
       msw: 2.10.4(@types/node@20.19.4)(typescript@5.8.3)
       vite: 7.0.5(@types/node@20.19.4)(jiti@2.4.2)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
 
-  '@vitest/mocker@3.2.4(msw@2.10.4(@types/node@24.0.10)(typescript@5.8.3))(vite@7.0.5(@types/node@20.19.4)(jiti@2.4.2)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      msw: 2.10.4(@types/node@24.0.10)(typescript@5.8.3)
-      vite: 7.0.5(@types/node@20.19.4)(jiti@2.4.2)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
-
   '@vitest/mocker@3.2.4(msw@2.10.4(@types/node@24.0.10)(typescript@5.8.3))(vite@7.0.5(@types/node@24.0.10)(jiti@2.4.2)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -20423,8 +20414,8 @@ snapshots:
       '@typescript-eslint/parser': 8.35.1(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.35.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.35.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -20447,7 +20438,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1
@@ -20458,22 +20449,22 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.0
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.35.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.35.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.35.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.35.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.35.1(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -20484,7 +20475,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.35.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.35.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -21838,7 +21829,7 @@ snapshots:
 
   jose@5.10.0: {}
 
-  jotai-optics@0.4.0(jotai@2.8.4(react@18.3.1))(optics-ts@2.4.1):
+  jotai-optics@0.4.0(jotai@2.8.4(@types/react@18.3.23)(react@18.3.1))(optics-ts@2.4.1):
     dependencies:
       jotai: 2.8.4(@types/react@18.3.23)(react@18.3.1)
       optics-ts: 2.4.1
@@ -25796,7 +25787,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@24.0.10)(typescript@5.8.3))(vite@7.0.5(@types/node@20.19.4)(jiti@2.4.2)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@24.0.10)(typescript@5.8.3))(vite@7.0.5(@types/node@24.0.10)(jiti@2.4.2)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -26203,7 +26194,7 @@ snapshots:
 
   zod@3.25.1: {}
 
-  zustand-x@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(zustand@5.0.7(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1))):
+  zustand-x@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)(zustand@5.0.7(@types/react@18.3.23)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1))):
     dependencies:
       immer: 10.1.1
       lodash.mapvalues: 4.6.0


### PR DESCRIPTION
Remove `React.memo` from components that accept `children` to improve rendering performance.

`React.memo` provides little to no performance benefit and can even introduce overhead when used on components that accept `children`. This is because the `children` prop is almost always a new reference on every render, negating the memoization and forcing a re-render anyway. This change removes `React.memo` from identified components where it was used with a `children` prop.

---
<a href="https://cursor.com/background-agent?bcId=bc-34bafe6b-8360-4de5-b13e-eda0eae0381a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-34bafe6b-8360-4de5-b13e-eda0eae0381a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

