### PR TITLE
Add version number support to routes

### DIFF
--- a/apps/web-tss/src/routes/app.chats.$chatId.dashboard.$dashboardId.metrics.$metricId.tsx
+++ b/apps/web-tss/src/routes/app.chats.$chatId.dashboard.$dashboardId.metrics.$metricId.tsx
@@ -1,8 +1,22 @@
 import { createFileRoute } from '@tanstack/react-router'
 
+// Search params interface for type safety
+interface RouteSearch {
+  dashboard_version_number?: number
+  metric_version_number?: number
+}
+
 export const Route = createFileRoute(
   '/app/chats/$chatId/dashboard/$dashboardId/metrics/$metricId',
 )({
+  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
+    dashboard_version_number: search.dashboard_version_number
+      ? Number(search.dashboard_version_number)
+      : undefined,
+    metric_version_number: search.metric_version_number
+      ? Number(search.metric_version_number)
+      : undefined,
+  }),
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.chats.$chatId.dashboard.$dashboardId.metrics.$metricId.tsx
+++ b/apps/web-tss/src/routes/app.chats.$chatId.dashboard.$dashboardId.metrics.$metricId.tsx
@@ -1,22 +1,15 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
 
-// Search params interface for type safety
-interface RouteSearch {
-  dashboard_version_number?: number
-  metric_version_number?: number
-}
+const searchParamsSchema = z.object({
+  dashboard_version_number: z.coerce.number().optional(),
+  metric_version_number: z.coerce.number().optional(),
+})
 
 export const Route = createFileRoute(
   '/app/chats/$chatId/dashboard/$dashboardId/metrics/$metricId',
 )({
-  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
-    dashboard_version_number: search.dashboard_version_number
-      ? Number(search.dashboard_version_number)
-      : undefined,
-    metric_version_number: search.metric_version_number
-      ? Number(search.metric_version_number)
-      : undefined,
-  }),
+  validateSearch: searchParamsSchema,
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.chats.$chatId.dashboard.$dashboardId.tsx
+++ b/apps/web-tss/src/routes/app.chats.$chatId.dashboard.$dashboardId.tsx
@@ -1,18 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
 
-// Search params interface for type safety
-interface RouteSearch {
-  dashboard_version_number?: number
-}
+const searchParamsSchema = z.object({
+  dashboard_version_number: z.coerce.number().optional(),
+})
 
 export const Route = createFileRoute(
   '/app/chats/$chatId/dashboard/$dashboardId',
 )({
-  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
-    dashboard_version_number: search.dashboard_version_number
-      ? Number(search.dashboard_version_number)
-      : undefined,
-  }),
+  validateSearch: searchParamsSchema,
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.chats.$chatId.dashboard.$dashboardId.tsx
+++ b/apps/web-tss/src/routes/app.chats.$chatId.dashboard.$dashboardId.tsx
@@ -1,8 +1,18 @@
 import { createFileRoute } from '@tanstack/react-router'
 
+// Search params interface for type safety
+interface RouteSearch {
+  dashboard_version_number?: number
+}
+
 export const Route = createFileRoute(
   '/app/chats/$chatId/dashboard/$dashboardId',
 )({
+  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
+    dashboard_version_number: search.dashboard_version_number
+      ? Number(search.dashboard_version_number)
+      : undefined,
+  }),
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.chats.$chatId.metrics.$metricId.tsx
+++ b/apps/web-tss/src/routes/app.chats.$chatId.metrics.$metricId.tsx
@@ -1,16 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
 
-// Search params interface for type safety
-interface RouteSearch {
-  metric_version_number?: number
-}
+const searchParamsSchema = z.object({
+  metric_version_number: z.coerce.number().optional(),
+})
 
 export const Route = createFileRoute('/app/chats/$chatId/metrics/$metricId')({
-  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
-    metric_version_number: search.metric_version_number
-      ? Number(search.metric_version_number)
-      : undefined,
-  }),
+  validateSearch: searchParamsSchema,
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.chats.$chatId.metrics.$metricId.tsx
+++ b/apps/web-tss/src/routes/app.chats.$chatId.metrics.$metricId.tsx
@@ -1,6 +1,16 @@
 import { createFileRoute } from '@tanstack/react-router'
 
+// Search params interface for type safety
+interface RouteSearch {
+  metric_version_number?: number
+}
+
 export const Route = createFileRoute('/app/chats/$chatId/metrics/$metricId')({
+  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
+    metric_version_number: search.metric_version_number
+      ? Number(search.metric_version_number)
+      : undefined,
+  }),
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.chats.$chatId.report.$reportId.metrics.$metricId.tsx
+++ b/apps/web-tss/src/routes/app.chats.$chatId.report.$reportId.metrics.$metricId.tsx
@@ -1,22 +1,15 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
 
-// Search params interface for type safety
-interface RouteSearch {
-  report_version_number?: number
-  metric_version_number?: number
-}
+const searchParamsSchema = z.object({
+  report_version_number: z.coerce.number().optional(),
+  metric_version_number: z.coerce.number().optional(),
+})
 
 export const Route = createFileRoute(
   '/app/chats/$chatId/report/$reportId/metrics/$metricId',
 )({
-  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
-    report_version_number: search.report_version_number
-      ? Number(search.report_version_number)
-      : undefined,
-    metric_version_number: search.metric_version_number
-      ? Number(search.metric_version_number)
-      : undefined,
-  }),
+  validateSearch: searchParamsSchema,
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.chats.$chatId.report.$reportId.metrics.$metricId.tsx
+++ b/apps/web-tss/src/routes/app.chats.$chatId.report.$reportId.metrics.$metricId.tsx
@@ -1,8 +1,22 @@
 import { createFileRoute } from '@tanstack/react-router'
 
+// Search params interface for type safety
+interface RouteSearch {
+  report_version_number?: number
+  metric_version_number?: number
+}
+
 export const Route = createFileRoute(
   '/app/chats/$chatId/report/$reportId/metrics/$metricId',
 )({
+  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
+    report_version_number: search.report_version_number
+      ? Number(search.report_version_number)
+      : undefined,
+    metric_version_number: search.metric_version_number
+      ? Number(search.metric_version_number)
+      : undefined,
+  }),
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.chats.$chatId.report.$reportId.tsx
+++ b/apps/web-tss/src/routes/app.chats.$chatId.report.$reportId.tsx
@@ -1,16 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
 
-// Search params interface for type safety
-interface RouteSearch {
-  report_version_number?: number
-}
+const searchParamsSchema = z.object({
+  report_version_number: z.coerce.number().optional(),
+})
 
 export const Route = createFileRoute('/app/chats/$chatId/report/$reportId')({
-  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
-    report_version_number: search.report_version_number
-      ? Number(search.report_version_number)
-      : undefined,
-  }),
+  validateSearch: searchParamsSchema,
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.chats.$chatId.report.$reportId.tsx
+++ b/apps/web-tss/src/routes/app.chats.$chatId.report.$reportId.tsx
@@ -1,6 +1,16 @@
 import { createFileRoute } from '@tanstack/react-router'
 
+// Search params interface for type safety
+interface RouteSearch {
+  report_version_number?: number
+}
+
 export const Route = createFileRoute('/app/chats/$chatId/report/$reportId')({
+  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
+    report_version_number: search.report_version_number
+      ? Number(search.report_version_number)
+      : undefined,
+  }),
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.collections.$collectionId.chats.$chatId.dashboards.$dashboardId.metrics.$metricId.tsx
+++ b/apps/web-tss/src/routes/app.collections.$collectionId.chats.$chatId.dashboards.$dashboardId.metrics.$metricId.tsx
@@ -1,8 +1,22 @@
 import { createFileRoute } from '@tanstack/react-router'
 
+// Search params interface for type safety
+interface RouteSearch {
+  dashboard_version_number?: number
+  metric_version_number?: number
+}
+
 export const Route = createFileRoute(
   '/app/collections/$collectionId/chats/$chatId/dashboards/$dashboardId/metrics/$metricId',
 )({
+  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
+    dashboard_version_number: search.dashboard_version_number
+      ? Number(search.dashboard_version_number)
+      : undefined,
+    metric_version_number: search.metric_version_number
+      ? Number(search.metric_version_number)
+      : undefined,
+  }),
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.collections.$collectionId.chats.$chatId.dashboards.$dashboardId.metrics.$metricId.tsx
+++ b/apps/web-tss/src/routes/app.collections.$collectionId.chats.$chatId.dashboards.$dashboardId.metrics.$metricId.tsx
@@ -1,22 +1,15 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
 
-// Search params interface for type safety
-interface RouteSearch {
-  dashboard_version_number?: number
-  metric_version_number?: number
-}
+const searchParamsSchema = z.object({
+  dashboard_version_number: z.coerce.number().optional(),
+  metric_version_number: z.coerce.number().optional(),
+})
 
 export const Route = createFileRoute(
   '/app/collections/$collectionId/chats/$chatId/dashboards/$dashboardId/metrics/$metricId',
 )({
-  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
-    dashboard_version_number: search.dashboard_version_number
-      ? Number(search.dashboard_version_number)
-      : undefined,
-    metric_version_number: search.metric_version_number
-      ? Number(search.metric_version_number)
-      : undefined,
-  }),
+  validateSearch: searchParamsSchema,
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.collections.$collectionId.chats.$chatId.dashboards.$dashboardId.tsx
+++ b/apps/web-tss/src/routes/app.collections.$collectionId.chats.$chatId.dashboards.$dashboardId.tsx
@@ -1,18 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
 
-// Search params interface for type safety
-interface RouteSearch {
-  dashboard_version_number?: number
-}
+const searchParamsSchema = z.object({
+  dashboard_version_number: z.coerce.number().optional(),
+})
 
 export const Route = createFileRoute(
   '/app/collections/$collectionId/chats/$chatId/dashboards/$dashboardId',
 )({
-  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
-    dashboard_version_number: search.dashboard_version_number
-      ? Number(search.dashboard_version_number)
-      : undefined,
-  }),
+  validateSearch: searchParamsSchema,
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.collections.$collectionId.chats.$chatId.dashboards.$dashboardId.tsx
+++ b/apps/web-tss/src/routes/app.collections.$collectionId.chats.$chatId.dashboards.$dashboardId.tsx
@@ -1,8 +1,18 @@
 import { createFileRoute } from '@tanstack/react-router'
 
+// Search params interface for type safety
+interface RouteSearch {
+  dashboard_version_number?: number
+}
+
 export const Route = createFileRoute(
   '/app/collections/$collectionId/chats/$chatId/dashboards/$dashboardId',
 )({
+  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
+    dashboard_version_number: search.dashboard_version_number
+      ? Number(search.dashboard_version_number)
+      : undefined,
+  }),
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.collections.$collectionId.chats.$chatId.metrics.$metricId.tsx
+++ b/apps/web-tss/src/routes/app.collections.$collectionId.chats.$chatId.metrics.$metricId.tsx
@@ -1,8 +1,18 @@
 import { createFileRoute } from '@tanstack/react-router'
 
+// Search params interface for type safety
+interface RouteSearch {
+  metric_version_number?: number
+}
+
 export const Route = createFileRoute(
   '/app/collections/$collectionId/chats/$chatId/metrics/$metricId',
 )({
+  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
+    metric_version_number: search.metric_version_number
+      ? Number(search.metric_version_number)
+      : undefined,
+  }),
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.collections.$collectionId.chats.$chatId.metrics.$metricId.tsx
+++ b/apps/web-tss/src/routes/app.collections.$collectionId.chats.$chatId.metrics.$metricId.tsx
@@ -1,18 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
 
-// Search params interface for type safety
-interface RouteSearch {
-  metric_version_number?: number
-}
+const searchParamsSchema = z.object({
+  metric_version_number: z.coerce.number().optional(),
+})
 
 export const Route = createFileRoute(
   '/app/collections/$collectionId/chats/$chatId/metrics/$metricId',
 )({
-  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
-    metric_version_number: search.metric_version_number
-      ? Number(search.metric_version_number)
-      : undefined,
-  }),
+  validateSearch: searchParamsSchema,
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.collections.$collectionId.dashboard.$dashboardId.metrics.$metricId.tsx
+++ b/apps/web-tss/src/routes/app.collections.$collectionId.dashboard.$dashboardId.metrics.$metricId.tsx
@@ -1,22 +1,15 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
 
-// Search params interface for type safety
-interface RouteSearch {
-  dashboard_version_number?: number
-  metric_version_number?: number
-}
+const searchParamsSchema = z.object({
+  dashboard_version_number: z.coerce.number().optional(),
+  metric_version_number: z.coerce.number().optional(),
+})
 
 export const Route = createFileRoute(
   '/app/collections/$collectionId/dashboard/$dashboardId/metrics/$metricId',
 )({
-  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
-    dashboard_version_number: search.dashboard_version_number
-      ? Number(search.dashboard_version_number)
-      : undefined,
-    metric_version_number: search.metric_version_number
-      ? Number(search.metric_version_number)
-      : undefined,
-  }),
+  validateSearch: searchParamsSchema,
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.collections.$collectionId.dashboard.$dashboardId.metrics.$metricId.tsx
+++ b/apps/web-tss/src/routes/app.collections.$collectionId.dashboard.$dashboardId.metrics.$metricId.tsx
@@ -1,8 +1,22 @@
 import { createFileRoute } from '@tanstack/react-router'
 
+// Search params interface for type safety
+interface RouteSearch {
+  dashboard_version_number?: number
+  metric_version_number?: number
+}
+
 export const Route = createFileRoute(
   '/app/collections/$collectionId/dashboard/$dashboardId/metrics/$metricId',
 )({
+  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
+    dashboard_version_number: search.dashboard_version_number
+      ? Number(search.dashboard_version_number)
+      : undefined,
+    metric_version_number: search.metric_version_number
+      ? Number(search.metric_version_number)
+      : undefined,
+  }),
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.collections.$collectionId.dashboard.$dashboardId.tsx
+++ b/apps/web-tss/src/routes/app.collections.$collectionId.dashboard.$dashboardId.tsx
@@ -1,8 +1,18 @@
 import { createFileRoute } from '@tanstack/react-router'
 
+// Search params interface for type safety
+interface RouteSearch {
+  dashboard_version_number?: number
+}
+
 export const Route = createFileRoute(
   '/app/collections/$collectionId/dashboard/$dashboardId',
 )({
+  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
+    dashboard_version_number: search.dashboard_version_number
+      ? Number(search.dashboard_version_number)
+      : undefined,
+  }),
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.collections.$collectionId.dashboard.$dashboardId.tsx
+++ b/apps/web-tss/src/routes/app.collections.$collectionId.dashboard.$dashboardId.tsx
@@ -1,18 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
 
-// Search params interface for type safety
-interface RouteSearch {
-  dashboard_version_number?: number
-}
+const searchParamsSchema = z.object({
+  dashboard_version_number: z.coerce.number().optional(),
+})
 
 export const Route = createFileRoute(
   '/app/collections/$collectionId/dashboard/$dashboardId',
 )({
-  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
-    dashboard_version_number: search.dashboard_version_number
-      ? Number(search.dashboard_version_number)
-      : undefined,
-  }),
+  validateSearch: searchParamsSchema,
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.collections.$collectionId.metrics.$metricId.tsx
+++ b/apps/web-tss/src/routes/app.collections.$collectionId.metrics.$metricId.tsx
@@ -1,8 +1,18 @@
 import { createFileRoute } from '@tanstack/react-router'
 
+// Search params interface for type safety
+interface RouteSearch {
+  metric_version_number?: number
+}
+
 export const Route = createFileRoute(
   '/app/collections/$collectionId/metrics/$metricId',
 )({
+  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
+    metric_version_number: search.metric_version_number
+      ? Number(search.metric_version_number)
+      : undefined,
+  }),
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.collections.$collectionId.metrics.$metricId.tsx
+++ b/apps/web-tss/src/routes/app.collections.$collectionId.metrics.$metricId.tsx
@@ -1,18 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
 
-// Search params interface for type safety
-interface RouteSearch {
-  metric_version_number?: number
-}
+const searchParamsSchema = z.object({
+  metric_version_number: z.coerce.number().optional(),
+})
 
 export const Route = createFileRoute(
   '/app/collections/$collectionId/metrics/$metricId',
 )({
-  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
-    metric_version_number: search.metric_version_number
-      ? Number(search.metric_version_number)
-      : undefined,
-  }),
+  validateSearch: searchParamsSchema,
   component: RouteComponent,
 })
 

--- a/apps/web-tss/src/routes/app.dashboards.$dashboardId.tsx
+++ b/apps/web-tss/src/routes/app.dashboards.$dashboardId.tsx
@@ -1,16 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod';
 
-// Search params interface for type safety
-interface DashboardSearch {
-  dashboard_version_number?: number;
-}
+const searchParamsSchema = z.object({
+  dashboard_version_number: z.coerce.number().optional(),
+});
 
 export const Route = createFileRoute('/app/dashboards/$dashboardId')({
-  validateSearch: (search: Record<string, unknown>): DashboardSearch => ({
-    dashboard_version_number: search.dashboard_version_number
-      ? Number(search.dashboard_version_number)
-      : undefined,
-  }),
+  validateSearch: searchParamsSchema,
   component: RouteComponent,
 });
 

--- a/apps/web-tss/src/routes/app.metrics.$metricId.tsx
+++ b/apps/web-tss/src/routes/app.metrics.$metricId.tsx
@@ -1,16 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod';
 
-// Search params interface for type safety
-interface RouteSearch {
-  metric_version_number?: number;
-}
+const searchParamsSchema = z.object({
+  metric_version_number: z.coerce.number().optional(),
+});
 
 export const Route = createFileRoute('/app/metrics/$metricId')({
-  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
-    metric_version_number: search.metric_version_number
-      ? Number(search.metric_version_number)
-      : undefined,
-  }),
+  validateSearch: searchParamsSchema,
   component: RouteComponent,
 });
 

--- a/apps/web-tss/src/routes/app.metrics.$metricId.tsx
+++ b/apps/web-tss/src/routes/app.metrics.$metricId.tsx
@@ -1,6 +1,16 @@
 import { createFileRoute } from '@tanstack/react-router';
 
+// Search params interface for type safety
+interface RouteSearch {
+  metric_version_number?: number;
+}
+
 export const Route = createFileRoute('/app/metrics/$metricId')({
+  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
+    metric_version_number: search.metric_version_number
+      ? Number(search.metric_version_number)
+      : undefined,
+  }),
   component: RouteComponent,
 });
 

--- a/apps/web-tss/src/routes/app.reports.$reportId.tsx
+++ b/apps/web-tss/src/routes/app.reports.$reportId.tsx
@@ -1,16 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod';
 
-// Search params interface for type safety
-interface RouteSearch {
-  report_version_number?: number;
-}
+const searchParamsSchema = z.object({
+  report_version_number: z.coerce.number().optional(),
+});
 
 export const Route = createFileRoute('/app/reports/$reportId')({
-  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
-    report_version_number: search.report_version_number
-      ? Number(search.report_version_number)
-      : undefined,
-  }),
+  validateSearch: searchParamsSchema,
   component: RouteComponent,
 });
 

--- a/apps/web-tss/src/routes/app.reports.$reportId.tsx
+++ b/apps/web-tss/src/routes/app.reports.$reportId.tsx
@@ -1,6 +1,16 @@
 import { createFileRoute } from '@tanstack/react-router';
 
+// Search params interface for type safety
+interface RouteSearch {
+  report_version_number?: number;
+}
+
 export const Route = createFileRoute('/app/reports/$reportId')({
+  validateSearch: (search: Record<string, unknown>): RouteSearch => ({
+    report_version_number: search.report_version_number
+      ? Number(search.report_version_number)
+      : undefined,
+  }),
   component: RouteComponent,
 });
 


### PR DESCRIPTION
Add version number query parameters to all dashboard, metric, and report routes to support versioning.

---
<a href="https://cursor.com/background-agent?bcId=bc-df777e2d-2c1a-4fa8-b580-ccbcf749d71f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df777e2d-2c1a-4fa8-b580-ccbcf749d71f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

