### PR TITLE
chore: update license to Business Source License 1.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,25 +1,65 @@
-Copyright (c) 2024 Sprint Labs, Inc.
+Business Source License 1.1
+
+Licensor: Sprint Labs, Inc.
+Licensed Work: Sprint Labs Software
+The Licensed Work is (c) 2024 Sprint Labs, Inc.
 
 Portions of this software are licensed as follows:
 
 - All content that resides under the "ee/" and/or "web/src/ee" directories of this repository, if these directories exist, is licensed under the license defined in "ee/LICENSE".
 - All third party components incorporated into the Sprint Labs Software are licensed under the original license provided by the owner of the applicable component.
-- Content outside of the above mentioned directories or restrictions above is available under the "MIT Expat" license as defined below.
+- Content outside of the above mentioned directories or restrictions above is available under the "Business Source License 1.1" as defined below.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+License Grant: You may make use of the Licensed Work, including running,
+modifying, and self-hosting it, provided that you do not offer the Licensed
+Work, in whole or in part, as a managed or hosted service where third
+parties pay you to use the Licensed Work or any substantial portion of its
+functionality. For clarity, you may use the Licensed Work internally for
+your own business operations or embed it within your own applications or
+services, so long as those services are not substantially a substitute for
+the Licensed Work itself.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Change Date: Three years from the date of each release of the Licensed Work.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Change License: On the Change Date for each release, that version of the
+Licensed Work will automatically become available under the following license:
+
+----------------------------------------------------------------------
+MIT License (Expat)
+
+Copyright (c) 2024 Sprint Labs, Inc.
+
+Portions of this software are licensed as follows:
+
+- All content that resides under the "ee/" and/or "web/src/ee" directories 
+  of this repository, if these directories exist, is licensed under the 
+  license defined in "ee/LICENSE".
+- All third party components incorporated into the Sprint Labs Software 
+  are licensed under the original license provided by the owner of the 
+  applicable component.
+- Content outside of the above mentioned directories or restrictions above 
+  is available under the "MIT Expat" license as defined below.
+
+Permission is hereby granted, free of charge, to any person obtaining a 
+copy of this software and associated documentation files (the "Software"), 
+to deal in the Software without restriction, including without limitation 
+the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+and/or sell copies of the Software, and to permit persons to whom the 
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in 
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+DEALINGS IN THE SOFTWARE.
+----------------------------------------------------------------------
+
+Clarification: This Change License applies only to versions of the Licensed
+Work released prior to their respective Change Dates. Sprint Labs, Inc. 
+reserves the right to license future versions of the Licensed Work under
+different terms, including proprietary licenses.


### PR DESCRIPTION
Updates the main codebase license from MIT to Business Source License 1.1. The BSL automatically converts to MIT after 3 years. The EE directory remains under the commercial license.