### PR TITLE
Fix divider border color to use global tailwind

### DIFF
--- a/apps/web/src/components/ui/report/elements/HrNode.tsx
+++ b/apps/web/src/components/ui/report/elements/HrNode.tsx
@@ -18,7 +18,7 @@ export function HrElement(props: PlateElementProps) {
       <div className="py-6" contentEditable={false}>
         <hr
           className={cn(
-            'bg-muted h-0.5 rounded-sm border-none bg-clip-content',
+            'border-border border-0 border-t',
             selected && focused && 'ring-ring ring-2 ring-offset-2',
             !readOnly && 'cursor-pointer'
           )}

--- a/apps/web/src/components/ui/report/elements/HrNodeStatic.tsx
+++ b/apps/web/src/components/ui/report/elements/HrNodeStatic.tsx
@@ -10,7 +10,7 @@ export function HrElementStatic(props: SlateElementProps) {
   return (
     <SlateElement {...props}>
       <div className="cursor-text py-6" contentEditable={false}>
-        <hr className={cn('bg-muted h-0.5 rounded-sm border-none bg-clip-content')} />
+        <hr className={cn('border-border border-0 border-t')} />
       </div>
       {props.children}
     </SlateElement>


### PR DESCRIPTION
Ensure editor dividers use the global Tailwind border color instead of a hardcoded background color.

---
<a href="https://cursor.com/background-agent?bcId=bc-793ac7c4-acab-4aa5-9582-fa4c7f69eaef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-793ac7c4-acab-4aa5-9582-fa4c7f69eaef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

