### PR TITLE
Enhance logging and update tests to remove hardcoded secrets

### DIFF
--- a/apps/api/server/src/main.rs
+++ b/apps/api/server/src/main.rs
@@ -133,6 +133,8 @@ async fn main() -> Result<(), anyhow::Error> {
         }
     };
 
+    info!("Server is running on http://0.0.0.0:{}", port_number);
+    
     let server = axum::serve(listener, app);
 
     tokio::select! {

--- a/apps/server/src/middleware/github-webhook-validator.test.ts
+++ b/apps/server/src/middleware/github-webhook-validator.test.ts
@@ -88,8 +88,6 @@ describe('githubWebhookValidator', () => {
   it('should reject request without signature header', async () => {
     const { app, body } = createMockContext(); // No signature
 
-    process.env.GITHUB_WEBHOOK_SECRET = 'test-secret';
-
     const res = await app.request('/', {
       method: 'POST',
       body,
@@ -102,8 +100,6 @@ describe('githubWebhookValidator', () => {
 
   it('should reject request with invalid signature', async () => {
     const { app, headers, body } = createMockContext('sha256=invalid-signature');
-
-    process.env.GITHUB_WEBHOOK_SECRET = 'test-secret';
 
     // Mock signature verification to return false
     vi.mocked(verifyGitHubWebhookSignature).mockReturnValue(false);
@@ -139,7 +135,6 @@ describe('githubWebhookValidator', () => {
   it('should reject request with invalid JSON payload', async () => {
     const { app, headers } = createMockContext('sha256=test-signature');
 
-    process.env.GITHUB_WEBHOOK_SECRET = 'test-secret';
     vi.mocked(verifyGitHubWebhookSignature).mockReturnValue(true);
 
     const res = await app.request('/', {
@@ -161,7 +156,6 @@ describe('githubWebhookValidator', () => {
 
     const { app, headers, body } = createMockContext('sha256=test-signature', invalidPayload);
 
-    process.env.GITHUB_WEBHOOK_SECRET = 'test-secret';
     vi.mocked(verifyGitHubWebhookSignature).mockReturnValue(true);
 
     // Mock schema to throw an error for invalid payload

--- a/apps/trigger/src/tasks/message-post-processing/helpers/slack-notifier.test.ts
+++ b/apps/trigger/src/tasks/message-post-processing/helpers/slack-notifier.test.ts
@@ -65,7 +65,6 @@ global.fetch = vi.fn();
 describe('slack-notifier', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.BUSTER_URL = 'https://platform.buster.so';
   });
 
   describe('formatSlackMessage with markdown conversion', () => {

--- a/packages/web-tools/src/services/firecrawl.test.ts
+++ b/packages/web-tools/src/services/firecrawl.test.ts
@@ -9,6 +9,14 @@ interface MockFirecrawlApp {
   search: ReturnType<typeof vi.fn>;
 }
 
+// Mock the @buster/secrets module
+vi.mock('@buster/secrets', () => ({
+  getSecret: vi.fn().mockResolvedValue('test-api-key'),
+  WEB_TOOLS_KEYS: {
+    FIRECRAWL_API_KEY: 'FIRECRAWL_API_KEY',
+  },
+}));
+
 // Mock the FirecrawlApp
 vi.mock('@mendable/firecrawl-js', () => {
   return {
@@ -28,23 +36,21 @@ describe('FirecrawlService', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Set API key for tests
-    process.env.FIRECRAWL_API_KEY = 'test-api-key';
   });
 
-  it('should create service with API key from environment', () => {
-    service = new FirecrawlService();
+  it('should create service with API key from secrets', async () => {
+    service = await FirecrawlService.create();
     expect(service).toBeInstanceOf(FirecrawlService);
   });
 
-  it('should create service with API key from config', () => {
-    service = new FirecrawlService({ apiKey: 'custom-api-key' });
+  it('should create service with API key from config', async () => {
+    service = await FirecrawlService.create({ apiKey: 'custom-api-key' });
     expect(service).toBeInstanceOf(FirecrawlService);
   });
 
   describe('startDeepResearch', () => {
-    beforeEach(() => {
-      service = new FirecrawlService();
+    beforeEach(async () => {
+      service = await FirecrawlService.create();
     });
 
     it('should start deep research with default options', async () => {
@@ -92,8 +98,8 @@ describe('FirecrawlService', () => {
   });
 
   describe('getJobStatus', () => {
-    beforeEach(() => {
-      service = new FirecrawlService();
+    beforeEach(async () => {
+      service = await FirecrawlService.create();
     });
 
     it('should get job status', async () => {
@@ -116,8 +122,8 @@ describe('FirecrawlService', () => {
   });
 
   describe('scrapeUrl', () => {
-    beforeEach(() => {
-      service = new FirecrawlService();
+    beforeEach(async () => {
+      service = await FirecrawlService.create();
     });
 
     it('should scrape URL with default options', async () => {
@@ -160,8 +166,8 @@ describe('FirecrawlService', () => {
   });
 
   describe('validateUrl', () => {
-    beforeEach(() => {
-      service = new FirecrawlService();
+    beforeEach(async () => {
+      service = await FirecrawlService.create();
     });
 
     it('should return true for valid accessible URL', async () => {
@@ -184,8 +190,8 @@ describe('FirecrawlService', () => {
   });
 
   describe('webSearch', () => {
-    beforeEach(() => {
-      service = new FirecrawlService();
+    beforeEach(async () => {
+      service = await FirecrawlService.create();
     });
 
     it('should perform web search with default options', async () => {


### PR DESCRIPTION
- Added logging for server startup with port number in main.rs
- Removed hardcoded GITHUB_WEBHOOK_SECRET from github-webhook-validator tests
- Updated slack-notifier tests to remove BUSTER_URL environment variable
- Refactored FirecrawlService tests to use async creation method and removed API key from environment