### PR TITLE
Style report callout card and add copy button

### DIFF
--- a/apps/web/src/components/ui/report/elements/CalloutNode.tsx
+++ b/apps/web/src/components/ui/report/elements/CalloutNode.tsx
@@ -30,7 +30,7 @@ export function CalloutElement({
 
   return (
     <PlateElement
-      className={cn('bg-muted flex rounded-sm p-4 pl-3', attributes.className)}
+      className={cn('bg-muted flex rounded-sm p-2 pl-3 my-2.5 relative group text-[15px] leading-[150%] font-normal', attributes.className)}
       style={{
         ...attributes.style,
         backgroundColor: element.backgroundColor

--- a/apps/web/src/components/ui/report/elements/CalloutNodeStatic.tsx
+++ b/apps/web/src/components/ui/report/elements/CalloutNodeStatic.tsx
@@ -3,6 +3,8 @@ import * as React from 'react';
 import type { SlateElementProps, TCalloutElement } from 'platejs';
 
 import { SlateElement } from 'platejs';
+import { Button } from '@/components/ui/buttons';
+import { NodeTypeIcons } from '../config/icons';
 
 import { cn } from '@/lib/utils';
 
@@ -11,9 +13,39 @@ export function CalloutElementStatic({
   className,
   ...props
 }: SlateElementProps<TCalloutElement>) {
+  const [hasCopied, setHasCopied] = React.useState(false);
+
+  React.useEffect(() => {
+    if (hasCopied) {
+      const timeout = setTimeout(() => {
+        setHasCopied(false);
+      }, 2000);
+      return () => clearTimeout(timeout);
+    }
+  }, [hasCopied]);
+
+  const handleCopy = () => {
+    // Extract text content from the children
+    const getTextContent = (node: unknown): string => {
+      if (typeof node === 'string') return node;
+      if (Array.isArray(node)) return node.map(getTextContent).join('');
+      if (node && typeof node === 'object' && 'props' in node) {
+        const reactNode = node as { props?: { children?: unknown } };
+        if (reactNode.props?.children) {
+          return getTextContent(reactNode.props.children);
+        }
+      }
+      return '';
+    };
+
+    const textContent = getTextContent(children);
+    void navigator.clipboard.writeText(textContent);
+    setHasCopied(true);
+  };
+
   return (
     <SlateElement
-      className={cn('bg-muted my-1 flex rounded-sm p-4 pl-3', className)}
+      className={cn('bg-muted my-2.5 flex rounded-sm p-2 pl-3 relative group text-[15px] leading-[150%] font-normal', className)}
       style={{
         backgroundColor: props.element.backgroundColor as string
       }}
@@ -28,6 +60,17 @@ export function CalloutElementStatic({
           <span data-plate-prevent-deserialization>{props.element.icon || '💡'}</span>
         </div>
         <div className="w-full">{children}</div>
+      </div>
+      
+      {/* Copy button - hidden by default, shown on hover */}
+      <div className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+        <Button
+          variant="ghost"
+          size="small"
+          onClick={handleCopy}
+          prefix={hasCopied ? <NodeTypeIcons.check /> : <NodeTypeIcons.copy />}
+          className="h-6 w-6 p-0"
+        />
       </div>
     </SlateElement>
   );


### PR DESCRIPTION
Update report callout styling and add a hover-activated copy button to meet design specifications and improve usability.

---
<a href="https://cursor.com/background-agent?bcId=bc-62307509-647a-4059-b794-b53a5cd983d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-62307509-647a-4059-b794-b53a5cd983d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

