### PR TITLE
Add Slack notification handling logic in message post-processing task

### DIFF
--- a/apps/trigger/src/tasks/message-post-processing/message-post-processing.ts
+++ b/apps/trigger/src/tasks/message-post-processing/message-post-processing.ts
@@ -234,11 +234,11 @@ export const messagePostProcessingTask: ReturnType<
       // Step 7: Send Slack notification if conditions are met
       let slackNotificationSent = false;
 
-      // Skip Slack notification if tool_called is "noIssuesFound" and there are no major assumptions
+      // Skip Slack notification if no issues were flagged and there are no major assumptions
       const hasMajorAssumptions =
         dbData.assumptions?.some((assumption) => assumption.label === 'major') ?? false;
       const shouldSkipSlackNotification =
-        dbData.tool_called === 'noIssuesFound' && !hasMajorAssumptions;
+        validatedOutput.flagChatResult.type === 'noIssuesFound' && !hasMajorAssumptions;
 
       try {
         logger.log('Checking Slack notification conditions', {

--- a/packages/ai/src/workflows/message-post-processing-workflow/message-post-processing-workflow.test.ts
+++ b/packages/ai/src/workflows/message-post-processing-workflow/message-post-processing-workflow.test.ts
@@ -1,0 +1,419 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { runMessagePostProcessingWorkflow } from './message-post-processing-workflow';
+import type { PostProcessingWorkflowInput } from './message-post-processing-workflow';
+
+// Mock the steps
+vi.mock('../../steps/message-post-processing-steps/flag-chat-step/flag-chat-step', () => ({
+  runFlagChatStep: vi.fn(),
+}));
+
+vi.mock(
+  '../../steps/message-post-processing-steps/identify-assumptions-step/identify-assumptions-step',
+  () => ({
+    runIdentifyAssumptionsStep: vi.fn(),
+  })
+);
+
+vi.mock(
+  '../../steps/message-post-processing-steps/format-follow-up-message-step/format-follow-up-message-step',
+  () => ({
+    runFormatFollowUpMessageStep: vi.fn(),
+  })
+);
+
+vi.mock(
+  '../../steps/message-post-processing-steps/format-initial-message-step/format-initial-message-step',
+  () => ({
+    runFormatInitialMessageStep: vi.fn(),
+  })
+);
+
+import { runFlagChatStep } from '../../steps/message-post-processing-steps/flag-chat-step/flag-chat-step';
+import { runFormatFollowUpMessageStep } from '../../steps/message-post-processing-steps/format-follow-up-message-step/format-follow-up-message-step';
+import { runFormatInitialMessageStep } from '../../steps/message-post-processing-steps/format-initial-message-step/format-initial-message-step';
+import { runIdentifyAssumptionsStep } from '../../steps/message-post-processing-steps/identify-assumptions-step/identify-assumptions-step';
+
+describe('runMessagePostProcessingWorkflow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Formatting logic edge cases', () => {
+    it('should format initial message when isSlackFollowUp is undefined', async () => {
+      // Setup
+      const input: PostProcessingWorkflowInput = {
+        userName: 'Test User',
+        datasets: 'test datasets',
+        isFollowUp: false,
+        isSlackFollowUp: undefined, // Critical test case
+      };
+
+      vi.mocked(runFlagChatStep).mockResolvedValue({
+        type: 'flagChat',
+        summaryMessage: 'Issues found',
+        summaryTitle: 'Test Issue',
+      });
+
+      vi.mocked(runIdentifyAssumptionsStep).mockResolvedValue({
+        toolCalled: 'listAssumptions',
+        assumptions: [
+          {
+            descriptiveTitle: 'Major assumption',
+            classification: 'fieldMapping',
+            explanation: 'Test explanation',
+            label: 'major',
+          },
+        ],
+      });
+
+      vi.mocked(runFormatInitialMessageStep).mockResolvedValue({
+        summaryMessage: 'Formatted initial message',
+        summaryTitle: 'Initial Title',
+      });
+
+      // Execute
+      const result = await runMessagePostProcessingWorkflow(input);
+
+      // Verify - should call format initial message when isSlackFollowUp is undefined
+      expect(runFormatInitialMessageStep).toHaveBeenCalledWith({
+        userName: 'Test User',
+        flaggedIssues: 'Issues found',
+        majorAssumptions: [
+          {
+            descriptiveTitle: 'Major assumption',
+            classification: 'fieldMapping',
+            explanation: 'Test explanation',
+            label: 'major',
+          },
+        ],
+        conversationHistory: undefined,
+      });
+
+      expect(result.formattedMessage).toBe('Formatted initial message');
+    });
+
+    it('should format initial message when isSlackFollowUp is false', async () => {
+      // Setup
+      const input: PostProcessingWorkflowInput = {
+        userName: 'Test User',
+        datasets: 'test datasets',
+        isFollowUp: false,
+        isSlackFollowUp: false, // Explicit false
+      };
+
+      vi.mocked(runFlagChatStep).mockResolvedValue({
+        type: 'flagChat',
+        summaryMessage: 'Issues found',
+        summaryTitle: 'Test Issue',
+      });
+
+      vi.mocked(runIdentifyAssumptionsStep).mockResolvedValue({
+        toolCalled: 'listAssumptions',
+        assumptions: [
+          {
+            descriptiveTitle: 'Major assumption',
+            classification: 'fieldMapping',
+            explanation: 'Test explanation',
+            label: 'major',
+          },
+        ],
+      });
+
+      vi.mocked(runFormatInitialMessageStep).mockResolvedValue({
+        summaryMessage: 'Formatted initial message',
+        summaryTitle: 'Initial Title',
+      });
+
+      // Execute
+      const result = await runMessagePostProcessingWorkflow(input);
+
+      // Verify
+      expect(runFormatInitialMessageStep).toHaveBeenCalled();
+      expect(result.formattedMessage).toBe('Formatted initial message');
+    });
+
+    it('should format follow-up message when both isFollowUp and isSlackFollowUp are true', async () => {
+      // Setup
+      const input: PostProcessingWorkflowInput = {
+        userName: 'Test User',
+        datasets: 'test datasets',
+        isFollowUp: true,
+        isSlackFollowUp: true,
+      };
+
+      vi.mocked(runFlagChatStep).mockResolvedValue({
+        type: 'flagChat',
+        summaryMessage: 'Issues found',
+        summaryTitle: 'Test Issue',
+      });
+
+      vi.mocked(runIdentifyAssumptionsStep).mockResolvedValue({
+        toolCalled: 'listAssumptions',
+        assumptions: [
+          {
+            descriptiveTitle: 'Major assumption',
+            classification: 'fieldMapping',
+            explanation: 'Test explanation',
+            label: 'major',
+          },
+        ],
+      });
+
+      vi.mocked(runFormatFollowUpMessageStep).mockResolvedValue({
+        summaryMessage: 'Formatted follow-up message',
+        summaryTitle: 'Follow-up Title',
+      });
+
+      // Execute
+      const result = await runMessagePostProcessingWorkflow(input);
+
+      // Verify
+      expect(runFormatFollowUpMessageStep).toHaveBeenCalled();
+      expect(runFormatInitialMessageStep).not.toHaveBeenCalled();
+      expect(result.formattedMessage).toBe('Formatted follow-up message');
+    });
+
+    it('should NOT format message when no major assumptions and no flagged issues', async () => {
+      // Setup
+      const input: PostProcessingWorkflowInput = {
+        userName: 'Test User',
+        datasets: 'test datasets',
+        isFollowUp: false,
+        isSlackFollowUp: false,
+      };
+
+      vi.mocked(runFlagChatStep).mockResolvedValue({
+        type: 'noIssuesFound',
+        message: 'No issues found',
+      });
+
+      vi.mocked(runIdentifyAssumptionsStep).mockResolvedValue({
+        toolCalled: 'noAssumptions',
+        assumptions: undefined,
+      });
+
+      // Execute
+      const result = await runMessagePostProcessingWorkflow(input);
+
+      // Verify - no formatting functions should be called
+      expect(runFormatInitialMessageStep).not.toHaveBeenCalled();
+      expect(runFormatFollowUpMessageStep).not.toHaveBeenCalled();
+      expect(result.formattedMessage).toBeUndefined();
+    });
+
+    it('should format message when major assumptions exist even without flagged issues', async () => {
+      // Setup
+      const input: PostProcessingWorkflowInput = {
+        userName: 'Test User',
+        datasets: 'test datasets',
+        isFollowUp: false,
+        isSlackFollowUp: false,
+      };
+
+      vi.mocked(runFlagChatStep).mockResolvedValue({
+        type: 'noIssuesFound',
+        message: 'No issues found',
+      });
+
+      vi.mocked(runIdentifyAssumptionsStep).mockResolvedValue({
+        toolCalled: 'listAssumptions',
+        assumptions: [
+          {
+            descriptiveTitle: 'Major assumption',
+            classification: 'fieldMapping',
+            explanation: 'Test explanation',
+            label: 'major',
+          },
+        ],
+      });
+
+      vi.mocked(runFormatInitialMessageStep).mockResolvedValue({
+        summaryMessage: 'Major assumptions require attention',
+        summaryTitle: 'Assumptions Found',
+      });
+
+      // Execute
+      const result = await runMessagePostProcessingWorkflow(input);
+
+      // Verify - should format because of major assumptions
+      expect(runFormatInitialMessageStep).toHaveBeenCalled();
+      expect(result.formattedMessage).toBe('Major assumptions require attention');
+    });
+
+    it('should NOT format message with only minor assumptions', async () => {
+      // Setup
+      const input: PostProcessingWorkflowInput = {
+        userName: 'Test User',
+        datasets: 'test datasets',
+        isFollowUp: false,
+        isSlackFollowUp: false,
+      };
+
+      vi.mocked(runFlagChatStep).mockResolvedValue({
+        type: 'noIssuesFound',
+        message: 'No issues found',
+      });
+
+      vi.mocked(runIdentifyAssumptionsStep).mockResolvedValue({
+        toolCalled: 'listAssumptions',
+        assumptions: [
+          {
+            descriptiveTitle: 'Minor assumption',
+            classification: 'fieldMapping',
+            explanation: 'Test explanation',
+            label: 'minor',
+          },
+        ],
+      });
+
+      // Execute
+      const result = await runMessagePostProcessingWorkflow(input);
+
+      // Verify - should NOT format because only minor assumptions
+      expect(runFormatInitialMessageStep).not.toHaveBeenCalled();
+      expect(runFormatFollowUpMessageStep).not.toHaveBeenCalled();
+      expect(result.formattedMessage).toBeUndefined();
+    });
+  });
+
+  describe('Result structure validation', () => {
+    it('should return correct structure for flagChat with assumptions', async () => {
+      const input: PostProcessingWorkflowInput = {
+        userName: 'Test User',
+        datasets: 'test datasets',
+      };
+
+      vi.mocked(runFlagChatStep).mockResolvedValue({
+        type: 'flagChat',
+        summaryMessage: 'Issues found',
+        summaryTitle: 'Test Issue',
+      });
+
+      vi.mocked(runIdentifyAssumptionsStep).mockResolvedValue({
+        toolCalled: 'listAssumptions',
+        assumptions: [
+          {
+            descriptiveTitle: 'Test assumption',
+            classification: 'fieldMapping',
+            explanation: 'Test explanation',
+            label: 'major',
+          },
+        ],
+      });
+
+      vi.mocked(runFormatInitialMessageStep).mockResolvedValue({
+        summaryMessage: 'Formatted message',
+        summaryTitle: 'Title',
+      });
+
+      const result = await runMessagePostProcessingWorkflow(input);
+
+      expect(result).toEqual({
+        flagChatResult: {
+          type: 'flagChat',
+          summaryMessage: 'Issues found',
+          summaryTitle: 'Test Issue',
+          message: undefined,
+        },
+        assumptionsResult: {
+          toolCalled: 'listAssumptions',
+          assumptions: [
+            {
+              descriptiveTitle: 'Test assumption',
+              classification: 'fieldMapping',
+              explanation: 'Test explanation',
+              label: 'major',
+            },
+          ],
+        },
+        formattedMessage: 'Formatted message',
+      });
+    });
+
+    it('should return correct structure for noIssuesFound with no assumptions', async () => {
+      const input: PostProcessingWorkflowInput = {
+        userName: 'Test User',
+        datasets: 'test datasets',
+      };
+
+      vi.mocked(runFlagChatStep).mockResolvedValue({
+        type: 'noIssuesFound',
+        message: 'All good',
+      });
+
+      vi.mocked(runIdentifyAssumptionsStep).mockResolvedValue({
+        toolCalled: 'noAssumptions',
+        assumptions: undefined,
+      });
+
+      const result = await runMessagePostProcessingWorkflow(input);
+
+      expect(result).toEqual({
+        flagChatResult: {
+          type: 'noIssuesFound',
+          summaryMessage: undefined,
+          summaryTitle: undefined,
+          message: 'All good',
+        },
+        assumptionsResult: {
+          toolCalled: 'noAssumptions',
+          assumptions: undefined,
+        },
+        formattedMessage: undefined,
+      });
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle all undefined optional fields', async () => {
+      const input: PostProcessingWorkflowInput = {
+        userName: 'Test User',
+        datasets: '',
+        conversationHistory: undefined,
+        isFollowUp: undefined,
+        isSlackFollowUp: undefined,
+      };
+
+      vi.mocked(runFlagChatStep).mockResolvedValue({
+        type: 'noIssuesFound',
+        message: 'No issues',
+      });
+
+      vi.mocked(runIdentifyAssumptionsStep).mockResolvedValue({
+        toolCalled: 'noAssumptions',
+        assumptions: undefined,
+      });
+
+      // Should not throw
+      const result = await runMessagePostProcessingWorkflow(input);
+
+      expect(result).toBeDefined();
+      expect(result.formattedMessage).toBeUndefined();
+    });
+
+    it('should handle empty datasets string', async () => {
+      const input: PostProcessingWorkflowInput = {
+        userName: 'Test User',
+        datasets: '',
+      };
+
+      vi.mocked(runFlagChatStep).mockResolvedValue({
+        type: 'noIssuesFound',
+        message: 'No issues',
+      });
+
+      vi.mocked(runIdentifyAssumptionsStep).mockResolvedValue({
+        toolCalled: 'noAssumptions',
+        assumptions: undefined,
+      });
+
+      const result = await runMessagePostProcessingWorkflow(input);
+
+      expect(runFlagChatStep).toHaveBeenCalledWith({
+        conversationHistory: undefined,
+        userName: 'Test User',
+        datasets: '',
+      });
+    });
+  });
+});

--- a/packages/ai/src/workflows/message-post-processing-workflow/message-post-processing-workflow.ts
+++ b/packages/ai/src/workflows/message-post-processing-workflow/message-post-processing-workflow.ts
@@ -91,8 +91,8 @@ export async function runMessagePostProcessingWorkflow(
         conversationHistory: validatedInput.conversationHistory,
       });
       formattedMessage = followUpResult.summaryMessage;
-    } else if (validatedInput.isSlackFollowUp === false) {
-      // Format initial message
+    } else if (!validatedInput.isSlackFollowUp) {
+      // Format initial message (when isSlackFollowUp is false or undefined)
       const initialResult = await runFormatInitialMessageStep({
         userName: validatedInput.userName,
         flaggedIssues,


### PR DESCRIPTION
- Implemented tests for Slack notification skip logic based on issue and assumption conditions.
- Updated the main task to skip notifications when no issues are found and no major assumptions exist.
- Enhanced workflow to handle undefined `isSlackFollowUp` correctly, ensuring proper message formatting and notification sending.