### PR TITLE
Add api endpoints for generating user suggested prompts

### DIFF
--- a/apps/server/src/api/v2/users/[id].ts
+++ b/apps/server/src/api/v2/users/[id].ts
@@ -1,19 +1,23 @@
 import { Hono } from 'hono';
+import suggestedPromptsRoutes from './id/suggested-prompts';
 
-const app = new Hono().get('/:id', (c) => {
-  const userId = c.req.param('id');
+const app = new Hono()
+  .get('/:id', (c) => {
+    const userId = c.req.param('id');
 
-  // Stub data for individual user
-  const stubUser = {
-    id: userId,
-    name: 'Example User',
-    email: `user${userId}@example.com`,
-    role: 'user',
-    createdAt: '2024-01-01T00:00:00Z',
-    updatedAt: '2024-01-01T00:00:00Z',
-  };
+    // Stub data for individual user
+    const stubUser = {
+      id: userId,
+      name: 'Example User',
+      email: `user${userId}@example.com`,
+      role: 'user',
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    };
 
-  return c.json(stubUser);
-});
+    return c.json(stubUser);
+  })
+  // Mount suggested prompts routes
+  .route('/:id/suggested-prompts', suggestedPromptsRoutes);
 
 export default app;

--- a/apps/server/src/api/v2/users/[id].ts
+++ b/apps/server/src/api/v2/users/[id].ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import suggestedPromptsRoutes from './id/suggested-prompts';
 
 const app = new Hono()
-  .get('/:id', (c) => {
+  .get('/', (c) => {
     const userId = c.req.param('id');
 
     // Stub data for individual user
@@ -17,7 +17,6 @@ const app = new Hono()
 
     return c.json(stubUser);
   })
-  // Mount suggested prompts routes
-  .route('/:id/suggested-prompts', suggestedPromptsRoutes);
+  .route('/suggested-prompts', suggestedPromptsRoutes);
 
 export default app;

--- a/apps/server/src/api/v2/users/id/suggested-prompts/GET.ts
+++ b/apps/server/src/api/v2/users/id/suggested-prompts/GET.ts
@@ -1,8 +1,5 @@
 import { getUserSuggestedPrompts } from '@buster/database';
-import {
-  GetSuggestedPromptsRequestSchema,
-  type SuggestedPromptsResponse,
-} from '@buster/server-shared/user';
+import { GetSuggestedPromptsRequestSchema } from '@buster/server-shared/user';
 import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
@@ -12,51 +9,28 @@ const app = new Hono().get(
   zValidator('query', GetSuggestedPromptsRequestSchema),
   async (c) => {
     try {
-      // Get the user ID from the route parameter
       const userId = c.req.param('id');
-      
-      // Get the authenticated user (for authorization)
+
       const authenticatedUser = c.get('busterUser');
-      
+
       // Authorization check: Users can only access their own suggested prompts
-      // (or add admin role check here if needed)
       if (authenticatedUser.id !== userId) {
-        throw new HTTPException(403, { 
-          message: 'Forbidden: You can only access your own suggested prompts' 
+        throw new HTTPException(403, {
+          message: 'Forbidden: You can only access your own suggested prompts',
         });
       }
 
-      // Get suggested prompts from database
       const suggestedPrompts = await getUserSuggestedPrompts({ userId });
 
-      if (!suggestedPrompts) {
-        // Return empty suggestions if user has none
-        const response: SuggestedPromptsResponse = {
-          suggestedPrompts: {
-            report: [],
-            dashboard: [],
-            visualization: [],
-            help: [],
-          },
-          updatedAt: new Date().toISOString(),
-        };
-        return c.json(response);
-      }
-
-      const response: SuggestedPromptsResponse = {
-        suggestedPrompts: suggestedPrompts.suggestedPrompts,
-        updatedAt: suggestedPrompts.updatedAt,
-      };
-
-      return c.json(response);
+      return c.json(suggestedPrompts);
     } catch (error) {
       if (error instanceof HTTPException) {
         throw error;
       }
-      
+
       console.error('[GetSuggestedPrompts] Error:', error);
-      throw new HTTPException(500, { 
-        message: 'Error fetching suggested prompts' 
+      throw new HTTPException(500, {
+        message: 'Error fetching suggested prompts',
       });
     }
   }

--- a/apps/server/src/api/v2/users/id/suggested-prompts/GET.ts
+++ b/apps/server/src/api/v2/users/id/suggested-prompts/GET.ts
@@ -1,0 +1,65 @@
+import { getUserSuggestedPrompts } from '@buster/database';
+import {
+  GetSuggestedPromptsRequestSchema,
+  type SuggestedPromptsResponse,
+} from '@buster/server-shared/user';
+import { zValidator } from '@hono/zod-validator';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+
+const app = new Hono().get(
+  '/',
+  zValidator('query', GetSuggestedPromptsRequestSchema),
+  async (c) => {
+    try {
+      // Get the user ID from the route parameter
+      const userId = c.req.param('id');
+      
+      // Get the authenticated user (for authorization)
+      const authenticatedUser = c.get('busterUser');
+      
+      // Authorization check: Users can only access their own suggested prompts
+      // (or add admin role check here if needed)
+      if (authenticatedUser.id !== userId) {
+        throw new HTTPException(403, { 
+          message: 'Forbidden: You can only access your own suggested prompts' 
+        });
+      }
+
+      // Get suggested prompts from database
+      const suggestedPrompts = await getUserSuggestedPrompts({ userId });
+
+      if (!suggestedPrompts) {
+        // Return empty suggestions if user has none
+        const response: SuggestedPromptsResponse = {
+          suggestedPrompts: {
+            report: [],
+            dashboard: [],
+            visualization: [],
+            help: [],
+          },
+          updatedAt: new Date().toISOString(),
+        };
+        return c.json(response);
+      }
+
+      const response: SuggestedPromptsResponse = {
+        suggestedPrompts: suggestedPrompts.suggestedPrompts,
+        updatedAt: suggestedPrompts.updatedAt,
+      };
+
+      return c.json(response);
+    } catch (error) {
+      if (error instanceof HTTPException) {
+        throw error;
+      }
+      
+      console.error('[GetSuggestedPrompts] Error:', error);
+      throw new HTTPException(500, { 
+        message: 'Error fetching suggested prompts' 
+      });
+    }
+  }
+);
+
+export default app;

--- a/apps/server/src/api/v2/users/id/suggested-prompts/POST.ts
+++ b/apps/server/src/api/v2/users/id/suggested-prompts/POST.ts
@@ -1,0 +1,137 @@
+import type { ModelMessage } from '@buster/ai';
+import { generateSuggestedMessages } from '@buster/ai';
+import { updateUserSuggestedPrompts } from '@buster/database';
+import {
+  GenerateSuggestedPromptsRequestSchema,
+  type SuggestedPromptsResponse,
+} from '@buster/server-shared/user';
+import { zValidator } from '@hono/zod-validator';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+
+/**
+ * Placeholder function to get database context for a user
+ * TODO: Implement this function to fetch user's database schemas and context
+ */
+async function getDatabaseContext(userId: string): Promise<string> {
+  // Placeholder implementation
+  console.info('[POST SuggestedPrompts] Getting database context for user:', userId);
+  
+  // TODO: Replace with actual implementation that:
+  // 1. Gets user's organization
+  // 2. Fetches permissioned datasets using @buster/access-controls
+  // 3. Formats dataset schemas into documentation string
+  // 4. Returns formatted database context
+  
+  return `
+# Sample Database Context for User ${userId}
+
+## Sales Data
+- Table: sales_transactions
+- Fields: transaction_id, customer_id, product_id, amount, date, region
+- Description: Daily sales transaction records
+
+## Customer Data  
+- Table: customers
+- Fields: customer_id, name, email, registration_date, tier
+- Description: Customer profile and segment information
+
+## Product Data
+- Table: products  
+- Fields: product_id, name, category, price, launch_date
+- Description: Product catalog and pricing information
+  `.trim();
+}
+
+/**
+ * Placeholder function to get user's chat history
+ * TODO: Implement this function to fetch recent user messages
+ */
+async function getUserChatHistory(userId: string): Promise<ModelMessage[]> {
+  // Placeholder implementation
+  console.info('[POST SuggestedPrompts] Getting chat history for user:', userId);
+  
+  // TODO: Replace with actual implementation that:
+  // 1. Calls getUserChatHistory from @buster/database
+  // 2. Converts message format to ModelMessage[]
+  // 3. Limits to recent messages (last 10-20)
+  // 4. Returns formatted chat history
+  
+  return [
+    {
+      role: 'user',
+      content: 'Show me sales performance for last quarter',
+    },
+    {
+      role: 'assistant', 
+      content: 'Here is your quarterly sales analysis...',
+    },
+    {
+      role: 'user',
+      content: 'Can you create a dashboard for customer metrics?',
+    },
+  ];
+}
+
+const app = new Hono().post(
+  '/',
+  zValidator('json', GenerateSuggestedPromptsRequestSchema),
+  async (c) => {
+    try {
+      // Get the user ID from the route parameter
+      const userId = c.req.param('id');
+      
+      // Get the authenticated user (for authorization)
+      const authenticatedUser = c.get('busterUser');
+      
+      // Authorization check: Users can only generate suggestions for themselves
+      // (or add admin role check here if needed)
+      if (authenticatedUser.id !== userId) {
+        throw new HTTPException(403, { 
+          message: 'Forbidden: You can only generate suggested prompts for yourself' 
+        });
+      }
+
+      console.info('[POST SuggestedPrompts] Generating suggestions for user:', userId);
+
+      // Step 1: Get database context (placeholder)
+      const databaseContext = await getDatabaseContext(userId);
+
+      // Step 2: Get user chat history (placeholder)
+      const chatHistory = await getUserChatHistory(userId);
+
+      // Step 3: Generate suggested prompts using AI task
+      const generatedPrompts = await generateSuggestedMessages({
+        chatHistory,
+        databaseContext,
+        userId,
+      });
+
+      // Step 4: Update the database with newly generated suggested prompts
+      const updatedPrompts = await updateUserSuggestedPrompts({
+        userId,
+        suggestedPrompts: generatedPrompts,
+      });
+
+      const response: SuggestedPromptsResponse = {
+        suggestedPrompts: updatedPrompts.suggestedPrompts,
+        updatedAt: updatedPrompts.updatedAt,
+      };
+
+      console.info('[POST SuggestedPrompts] Successfully generated and saved suggestions for user:', userId);
+
+      return c.json(response);
+    } catch (error) {
+      if (error instanceof HTTPException) {
+        throw error;
+      }
+      
+      console.error('[POST SuggestedPrompts] Error generating suggestions:', error);
+      throw new HTTPException(500, { 
+        message: 'Error generating suggested prompts' 
+      });
+    }
+  }
+);
+
+export default app;

--- a/apps/server/src/api/v2/users/id/suggested-prompts/index.ts
+++ b/apps/server/src/api/v2/users/id/suggested-prompts/index.ts
@@ -1,0 +1,13 @@
+import { Hono } from 'hono';
+import { requireAuth } from '../../../../../middleware/auth';
+import GET from './GET';
+import POST from './POST';
+
+const app = new Hono()
+  // Apply authentication to all routes
+  .use('*', requireAuth)
+  // Mount the route handlers
+  .route('/', GET)
+  .route('/', POST);
+
+export default app;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vite build -- --typecheck",
     "build:staging": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vite build --mode staging",
     "build:production": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vite build --mode production -- --typecheck",
-    "build:local": "cross-env NODE_OPTIONS=--max-old-space-size=12288 vite build -- --typecheck --local",
+    "build:local": "pnpm prebuild && cross-env NODE_OPTIONS=--max-old-space-size=12288 vite build -- --typecheck --local",
     "build-storybook": "storybook build",
     "build:visualize": "npx vite-bundle-visualizer",
     "deploy:dev": "pnpm run build && npx wrangler deploy .output/server/index.mjs --env dev --assets .output/public",

--- a/apps/web/src/api/createAxiosInstance.ts
+++ b/apps/web/src/api/createAxiosInstance.ts
@@ -69,7 +69,6 @@ export const defaultAxiosRequestHandler = async (config: InternalAxiosRequestCon
       token = await getSupabaseSessionServerFn().then(
         ({ data: { session } }) => session.access_token
       );
-      console.log('token', token);
     } else {
       // Always check token validity before making requests
       const tokenResult = await checkTokenValidity();

--- a/apps/web/src/api/server-functions/getSupabaseSession.ts
+++ b/apps/web/src/api/server-functions/getSupabaseSession.ts
@@ -11,7 +11,6 @@ export const getSupabaseSessionServerFn = createServerFn({ method: 'GET' }).hand
     expires_at: session?.expires_at,
     expires_in: session?.expires_in,
   };
-  console.log('pickedSession', JSON.stringify(pickedSession));
 
   return {
     data: {

--- a/apps/web/src/components/features/auth/SignOutHandler.tsx
+++ b/apps/web/src/components/features/auth/SignOutHandler.tsx
@@ -4,8 +4,6 @@ import { useBusterNotifications } from '@/context/BusterNotifications';
 import { signOut } from '@/integrations/supabase/signOut';
 import { clearAllBrowserStorage } from '@/lib/storage';
 
-const navigate = useNavigate();
-
 export const useSignOut = () => {
   const { openErrorMessage } = useBusterNotifications();
   const navigate = useNavigate();

--- a/apps/web/src/components/features/global/ComponentErrorCard.tsx
+++ b/apps/web/src/components/features/global/ComponentErrorCard.tsx
@@ -1,0 +1,24 @@
+import { ErrorBoundary } from 'react-error-boundary';
+import { rustErrorHandler } from '@/api/errors';
+import { ErrorCard } from './GlobalErrorCard';
+
+export const ComponentErrorCard = ({
+  children,
+  header,
+  message,
+}: {
+  children: React.ReactNode;
+  header?: string;
+  message?: string;
+}) => {
+  return (
+    <ErrorBoundary
+      fallbackRender={(e) => {
+        const errorMessage: string | undefined = rustErrorHandler(e).message || undefined;
+        return <ErrorCard header={header} message={errorMessage || message} />;
+      }}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+};

--- a/apps/web/src/components/features/global/GlobalErrorCard.tsx
+++ b/apps/web/src/components/features/global/GlobalErrorCard.tsx
@@ -3,8 +3,19 @@ import { usePostHog } from 'posthog-js/react';
 import { useEffect } from 'react';
 import { Button } from '@/components/ui/buttons';
 import { Card, CardContent, CardFooter } from '@/components/ui/card/CardBase';
+import { useMount } from '../../../hooks/useMount';
 
-export const ErrorCard = () => {
+export const ErrorCard = ({
+  header = 'Looks like we hit an unexpected error',
+  message = "Our team has been notified via Slack. We'll take a look at the issue ASAP and get back to you.",
+}: {
+  header?: string;
+  message?: string;
+}) => {
+  useMount(() => {
+    console.error('Error in card:', header, message);
+  });
+
   return (
     <div
       className=" flex h-full w-full flex-col items-center absolute inset-0 justify-center bg-linear-to-br bg-background p-8 backdrop-blur-xs backdrop-filter"
@@ -13,11 +24,9 @@ export const ErrorCard = () => {
       <Card className="-mt-10 max-w-100">
         <CardContent>
           <div className="flex flex-col gap-4">
-            <h1 className="text-2xl font-medium">Looks like we hit an unexpected error</h1>
+            <h1 className="text-2xl font-medium">{header}</h1>
 
-            <h5 className="m-0 text-base font-medium text-gray-600">
-              {`Our team has been notified via Slack. We'll take a look at the issue ASAP and get back to you.`}
-            </h5>
+            <h5 className="m-0 text-base font-medium text-gray-600">{message}</h5>
           </div>
         </CardContent>
 
@@ -42,8 +51,6 @@ export const GlobalErrorCard: ErrorRouteComponent = ({ error }) => {
     if (isPosthogLoaded) {
       posthog.captureException(error);
     }
-
-    console.error('GlobalErrorCard error', error);
   }, [error]);
 
   return <ErrorCard />;

--- a/apps/web/src/components/features/sidebars/SidebarSettings.tsx
+++ b/apps/web/src/components/features/sidebars/SidebarSettings.tsx
@@ -6,6 +6,7 @@ import CircleUser from '@/components/ui/icons/NucleoIconOutlined/circle-user';
 import { createSidebarGroup } from '@/components/ui/sidebar/create-sidebar-item';
 import LockCircle from '../../ui/icons/NucleoIconOutlined/lock-circle';
 import { type ISidebarGroup, Sidebar } from '../../ui/sidebar';
+import { ComponentErrorCard } from '../global/ComponentErrorCard';
 import { SidebarUserFooter } from './SidebarUserFooter';
 
 const accountItems: ISidebarGroup = createSidebarGroup({
@@ -107,12 +108,14 @@ export const SidebarSettings = () => {
   }, [isAdmin]);
 
   return (
-    <Sidebar
-      content={sidebarItems}
-      header={useMemo(() => <SidebarSettingsHeader />, [])}
-      footer={useMemo(() => <SidebarUserFooter />, [])}
-      useCollapsible={isUserRegistered}
-    />
+    <ComponentErrorCard header="Settings Sidebar">
+      <Sidebar
+        content={sidebarItems}
+        header={useMemo(() => <SidebarSettingsHeader />, [])}
+        footer={useMemo(() => <SidebarUserFooter />, [])}
+        useCollapsible={isUserRegistered}
+      />
+    </ComponentErrorCard>
   );
 };
 

--- a/apps/web/src/components/ui/report/elements/InlineCombobox.tsx
+++ b/apps/web/src/components/ui/report/elements/InlineCombobox.tsx
@@ -210,7 +210,6 @@ const InlineComboboxInput = React.forwardRef<
       })?.width + 8
     );
   }, [placeholder]);
-  console.log(placeHolderWidth);
 
   /**
    * To create an auto-resizing input, we render a visually hidden span

--- a/apps/web/src/context/Posthog/BusterPosthogProvider.tsx
+++ b/apps/web/src/context/Posthog/BusterPosthogProvider.tsx
@@ -7,6 +7,7 @@ import {
   useGetUserBasicInfo,
   useGetUserOrganization,
 } from '@/api/buster_rest/users/useGetUserInfo';
+import { ComponentErrorCard } from '@/components/features/global/ComponentErrorCard';
 import { isDev } from '@/config/dev';
 import { env } from '@/env';
 import packageJson from '../../../package.json';
@@ -16,16 +17,18 @@ const POSTHOG_KEY = env.VITE_PUBLIC_POSTHOG_KEY;
 const DEBUG_POSTHOG = false;
 
 export const BusterPosthogProvider: React.FC<PropsWithChildren> = ({ children }) => {
-  console.log('POSTHOG_KEY', POSTHOG_KEY);
-  console.log('DEBUG_POSTHOG', DEBUG_POSTHOG);
   if ((isDev && !DEBUG_POSTHOG) || !POSTHOG_KEY) {
     return <>{children}</>;
   }
 
-  console.log('POSTHOG_KEY22', POSTHOG_KEY);
-  console.log('DEBUG_POSTHOG22', DEBUG_POSTHOG);
-
-  return <PosthogWrapper>{children}</PosthogWrapper>;
+  return (
+    <ComponentErrorCard
+      header="Posthog failed to load"
+      message="Our team has been notified via Slack. We'll take a look at the issue ASAP and get back to you."
+    >
+      <PosthogWrapper>{children}</PosthogWrapper>
+    </ComponentErrorCard>
+  );
 };
 BusterPosthogProvider.displayName = 'BusterPosthogProvider';
 
@@ -49,7 +52,6 @@ const options: Partial<PostHogConfig> = {
 };
 
 const PosthogWrapper: React.FC<PropsWithChildren> = ({ children }) => {
-  console.log('PosthogWrapper');
   const user = useGetUserBasicInfo();
   const { data: userTeams } = useGetUserTeams({ userId: user?.id ?? '' });
   const userOrganizations = useGetUserOrganization();
@@ -112,8 +114,6 @@ const PosthogWrapper: React.FC<PropsWithChildren> = ({ children }) => {
   if (isServer) {
     return <>{children}</>;
   }
-
-  console.log('PostHogProvider!!!!', PostHogProvider);
 
   return (
     <ClientOnly>

--- a/apps/web/src/context/Providers.tsx
+++ b/apps/web/src/context/Providers.tsx
@@ -17,8 +17,6 @@ export const AppProviders: React.FC<PropsWithChildren<SupabaseContextType>> = ({
   user,
   accessToken,
 }) => {
-  console.log('user11', user);
-  console.log('accessToken11', accessToken);
   return (
     <SupabaseContextProvider user={user} accessToken={accessToken}>
       <BusterPosthogProvider>{children}</BusterPosthogProvider>

--- a/apps/web/src/context/Supabase/SupabaseContextProvider.tsx
+++ b/apps/web/src/context/Supabase/SupabaseContextProvider.tsx
@@ -66,10 +66,7 @@ export const SupabaseContext = createContext<ReturnType<typeof useSupabaseContex
 export const SupabaseContextProvider: React.FC<
   SupabaseContextType & { children: React.ReactNode }
 > = React.memo(({ user, accessToken, children }) => {
-  console.log('user22', user);
-  console.log('accessToken22', accessToken);
   const value = useSupabaseContextInternal({ user, accessToken });
-  console.log('value22', value);
 
   return <SupabaseContext.Provider value={value}>{children}</SupabaseContext.Provider>;
 });

--- a/apps/web/src/integrations/supabase/signIn.ts
+++ b/apps/web/src/integrations/supabase/signIn.ts
@@ -13,8 +13,6 @@ const isValidRedirectUrl = (url: string): boolean => {
   }
 };
 
-const fallbackCallbackUrl = `${env.VITE_PUBLIC_URL}/auth/callback`;
-
 // Common OAuth handler to reduce code duplication
 const handleOAuthSignIn = async (
   provider: 'google' | 'github' | 'azure',
@@ -55,6 +53,7 @@ export const signInWithEmailAndPassword = createServerFn({ method: 'POST' })
   )
   .handler(async ({ data }) => {
     const supabase = getSupabaseServerClient();
+
     const { error } = await supabase.auth.signInWithPassword({
       email: data.email,
       password: data.password,

--- a/apps/web/src/layouts/SettingsAppLayout.tsx
+++ b/apps/web/src/layouts/SettingsAppLayout.tsx
@@ -1,4 +1,5 @@
 import type React from 'react';
+import { ComponentErrorCard } from '@/components/features/global/ComponentErrorCard';
 import { SidebarSettings } from '@/components/features/sidebars/SidebarSettings';
 import { AppLayout, type LayoutSize } from '@/components/ui/layouts/AppLayout';
 
@@ -16,13 +17,15 @@ export const SettingsAppLayout: React.FC<IPrimaryAppLayoutProps> = ({
   defaultLayout,
 }) => {
   return (
-    <AppLayout
-      autoSaveId={layoutId}
-      defaultLayout={defaultLayout}
-      initialLayout={initialLayout}
-      sidebar={<SidebarSettings />}
-    >
-      {children}
-    </AppLayout>
+    <ComponentErrorCard header="Settings App Layout">
+      <AppLayout
+        autoSaveId={layoutId}
+        defaultLayout={defaultLayout}
+        initialLayout={initialLayout}
+        sidebar={<SidebarSettings />}
+      >
+        {children}
+      </AppLayout>
+    </ComponentErrorCard>
   );
 };

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as AppIndexRouteImport } from './routes/app/index'
 import { Route as AuthResetPasswordRouteImport } from './routes/auth.reset-password'
 import { Route as AuthLogoutRouteImport } from './routes/auth.logout'
 import { Route as AuthLoginRouteImport } from './routes/auth.login'
+import { Route as AppHealthcheckRouteImport } from './routes/app/healthcheck'
 import { Route as AppSettingsRouteImport } from './routes/app/_settings'
 import { Route as AppAppRouteImport } from './routes/app/_app'
 import { Route as EmbedReportReportIdRouteImport } from './routes/embed.report.$reportId'
@@ -29,6 +30,7 @@ import { Route as AppSettingsRestricted_layoutRouteImport } from './routes/app/_
 import { Route as AppSettingsPermissionsRouteImport } from './routes/app/_settings/_permissions'
 import { Route as AppAppHomeRouteImport } from './routes/app/_app/home'
 import { Route as AppAppAssetRouteImport } from './routes/app/_app/_asset'
+import { Route as AppSettingsSettingsIndexRouteImport } from './routes/app/_settings/settings.index'
 import { Route as AppAppReportsIndexRouteImport } from './routes/app/_app/reports.index'
 import { Route as AppAppMetricsIndexRouteImport } from './routes/app/_app/metrics.index'
 import { Route as AppAppLogsIndexRouteImport } from './routes/app/_app/logs.index'
@@ -198,6 +200,11 @@ const AuthLoginRoute = AuthLoginRouteImport.update({
   path: '/login',
   getParentRoute: () => AuthRoute,
 } as any)
+const AppHealthcheckRoute = AppHealthcheckRouteImport.update({
+  id: '/healthcheck',
+  path: '/healthcheck',
+  getParentRoute: () => AppRoute,
+} as any)
 const AppSettingsRoute = AppSettingsRouteImport.update({
   id: '/_settings',
   getParentRoute: () => AppRoute,
@@ -240,6 +247,12 @@ const AppAppAssetRoute = AppAppAssetRouteImport.update({
   id: '/_asset',
   getParentRoute: () => AppAppRoute,
 } as any)
+const AppSettingsSettingsIndexRoute =
+  AppSettingsSettingsIndexRouteImport.update({
+    id: '/settings/',
+    path: '/settings/',
+    getParentRoute: () => AppSettingsRoute,
+  } as any)
 const AppAppReportsIndexRoute = AppAppReportsIndexRouteImport.update({
   id: '/reports/',
   path: '/reports/',
@@ -913,6 +926,7 @@ export interface FileRoutesByFullPath {
   '/app': typeof AppSettingsRestricted_layoutAdmin_onlyRouteWithChildren
   '/auth': typeof AuthRouteWithChildren
   '/healthcheck': typeof HealthcheckRoute
+  '/app/healthcheck': typeof AppHealthcheckRoute
   '/auth/login': typeof AuthLoginRoute
   '/auth/logout': typeof AuthLogoutRoute
   '/auth/reset-password': typeof AuthResetPasswordRoute
@@ -929,6 +943,7 @@ export interface FileRoutesByFullPath {
   '/app/logs': typeof AppAppLogsIndexRoute
   '/app/metrics': typeof AppAppMetricsIndexRoute
   '/app/reports': typeof AppAppReportsIndexRoute
+  '/app/settings': typeof AppSettingsSettingsIndexRoute
   '/app/chats/$chatId': typeof AppAppAssetChatsChatIdRouteWithChildren
   '/app/datasets/$datasetId/editor': typeof AppAppDatasetsDatasetIdEditorRoute
   '/app/datasets/$datasetId/overview': typeof AppAppDatasetsDatasetIdOverviewRoute
@@ -1018,6 +1033,7 @@ export interface FileRoutesByTo {
   '/auth': typeof AuthRouteWithChildren
   '/healthcheck': typeof HealthcheckRoute
   '/app': typeof AppSettingsRestricted_layoutAdmin_onlyRouteWithChildren
+  '/app/healthcheck': typeof AppHealthcheckRoute
   '/auth/login': typeof AuthLoginRoute
   '/auth/logout': typeof AuthLogoutRoute
   '/auth/reset-password': typeof AuthResetPasswordRoute
@@ -1033,6 +1049,7 @@ export interface FileRoutesByTo {
   '/app/logs': typeof AppAppLogsIndexRoute
   '/app/metrics': typeof AppAppMetricsIndexRoute
   '/app/reports': typeof AppAppReportsIndexRoute
+  '/app/settings': typeof AppSettingsSettingsIndexRoute
   '/app/datasets/$datasetId/editor': typeof AppAppDatasetsDatasetIdEditorRoute
   '/app/datasets/$datasetId/overview': typeof AppAppDatasetsDatasetIdOverviewRoute
   '/app/settings/profile': typeof AppSettingsRestricted_layoutSettingsProfileRoute
@@ -1108,6 +1125,7 @@ export interface FileRoutesById {
   '/healthcheck': typeof HealthcheckRoute
   '/app/_app': typeof AppAppRouteWithChildren
   '/app/_settings': typeof AppSettingsRouteWithChildren
+  '/app/healthcheck': typeof AppHealthcheckRoute
   '/auth/login': typeof AuthLoginRoute
   '/auth/logout': typeof AuthLogoutRoute
   '/auth/reset-password': typeof AuthResetPasswordRoute
@@ -1128,6 +1146,7 @@ export interface FileRoutesById {
   '/app/_app/logs/': typeof AppAppLogsIndexRoute
   '/app/_app/metrics/': typeof AppAppMetricsIndexRoute
   '/app/_app/reports/': typeof AppAppReportsIndexRoute
+  '/app/_settings/settings/': typeof AppSettingsSettingsIndexRoute
   '/app/_app/_asset/chats/$chatId': typeof AppAppAssetChatsChatIdRouteWithChildren
   '/app/_app/datasets/$datasetId/editor': typeof AppAppDatasetsDatasetIdEditorRoute
   '/app/_app/datasets/$datasetId/overview': typeof AppAppDatasetsDatasetIdOverviewRoute
@@ -1229,6 +1248,7 @@ export interface FileRouteTypes {
     | '/app'
     | '/auth'
     | '/healthcheck'
+    | '/app/healthcheck'
     | '/auth/login'
     | '/auth/logout'
     | '/auth/reset-password'
@@ -1245,6 +1265,7 @@ export interface FileRouteTypes {
     | '/app/logs'
     | '/app/metrics'
     | '/app/reports'
+    | '/app/settings'
     | '/app/chats/$chatId'
     | '/app/datasets/$datasetId/editor'
     | '/app/datasets/$datasetId/overview'
@@ -1334,6 +1355,7 @@ export interface FileRouteTypes {
     | '/auth'
     | '/healthcheck'
     | '/app'
+    | '/app/healthcheck'
     | '/auth/login'
     | '/auth/logout'
     | '/auth/reset-password'
@@ -1349,6 +1371,7 @@ export interface FileRouteTypes {
     | '/app/logs'
     | '/app/metrics'
     | '/app/reports'
+    | '/app/settings'
     | '/app/datasets/$datasetId/editor'
     | '/app/datasets/$datasetId/overview'
     | '/app/settings/profile'
@@ -1423,6 +1446,7 @@ export interface FileRouteTypes {
     | '/healthcheck'
     | '/app/_app'
     | '/app/_settings'
+    | '/app/healthcheck'
     | '/auth/login'
     | '/auth/logout'
     | '/auth/reset-password'
@@ -1443,6 +1467,7 @@ export interface FileRouteTypes {
     | '/app/_app/logs/'
     | '/app/_app/metrics/'
     | '/app/_app/reports/'
+    | '/app/_settings/settings/'
     | '/app/_app/_asset/chats/$chatId'
     | '/app/_app/datasets/$datasetId/editor'
     | '/app/_app/datasets/$datasetId/overview'
@@ -1627,6 +1652,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthLoginRouteImport
       parentRoute: typeof AuthRoute
     }
+    '/app/healthcheck': {
+      id: '/app/healthcheck'
+      path: '/healthcheck'
+      fullPath: '/app/healthcheck'
+      preLoaderRoute: typeof AppHealthcheckRouteImport
+      parentRoute: typeof AppRoute
+    }
     '/app/_settings': {
       id: '/app/_settings'
       path: ''
@@ -1689,6 +1721,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/app'
       preLoaderRoute: typeof AppAppAssetRouteImport
       parentRoute: typeof AppAppRoute
+    }
+    '/app/_settings/settings/': {
+      id: '/app/_settings/settings/'
+      path: '/settings'
+      fullPath: '/app/settings'
+      preLoaderRoute: typeof AppSettingsSettingsIndexRouteImport
+      parentRoute: typeof AppSettingsRoute
     }
     '/app/_app/reports/': {
       id: '/app/_app/reports/'
@@ -3120,12 +3159,14 @@ const AppSettingsRestricted_layoutRouteWithChildren =
 interface AppSettingsRouteChildren {
   AppSettingsPermissionsRoute: typeof AppSettingsPermissionsRouteWithChildren
   AppSettingsRestricted_layoutRoute: typeof AppSettingsRestricted_layoutRouteWithChildren
+  AppSettingsSettingsIndexRoute: typeof AppSettingsSettingsIndexRoute
 }
 
 const AppSettingsRouteChildren: AppSettingsRouteChildren = {
   AppSettingsPermissionsRoute: AppSettingsPermissionsRouteWithChildren,
   AppSettingsRestricted_layoutRoute:
     AppSettingsRestricted_layoutRouteWithChildren,
+  AppSettingsSettingsIndexRoute: AppSettingsSettingsIndexRoute,
 }
 
 const AppSettingsRouteWithChildren = AppSettingsRoute._addFileChildren(
@@ -3135,12 +3176,14 @@ const AppSettingsRouteWithChildren = AppSettingsRoute._addFileChildren(
 interface AppRouteChildren {
   AppAppRoute: typeof AppAppRouteWithChildren
   AppSettingsRoute: typeof AppSettingsRouteWithChildren
+  AppHealthcheckRoute: typeof AppHealthcheckRoute
   AppIndexRoute: typeof AppIndexRoute
 }
 
 const AppRouteChildren: AppRouteChildren = {
   AppAppRoute: AppAppRouteWithChildren,
   AppSettingsRoute: AppSettingsRouteWithChildren,
+  AppHealthcheckRoute: AppHealthcheckRoute,
   AppIndexRoute: AppIndexRoute,
 }
 

--- a/apps/web/src/routes/app.tsx
+++ b/apps/web/src/routes/app.tsx
@@ -39,11 +39,11 @@ export const Route = createFileRoute('/app')({
         ]);
 
       console.log('initialLayout', initialLayout);
-      console.log('user', user);
-      console.log('userInfo', userInfo);
-      console.log('userFavorites', userFavorites);
-      console.log('listDatasources', listDatasources);
-      console.log('datasets', datasets);
+      console.log('user', user?.id);
+      console.log('userInfo', userInfo?.user?.id);
+      console.log('userFavorites', userFavorites?.length);
+      console.log('listDatasources', listDatasources?.length);
+      console.log('datasets', datasets?.length);
 
       if (!user) {
         throw redirect({ to: '/auth/login' });
@@ -63,8 +63,6 @@ export const Route = createFileRoute('/app')({
   },
   component: () => {
     const { user, accessToken } = Route.useLoaderData();
-    console.log('user', user);
-    console.log('accessToken', accessToken);
 
     return (
       <AppProviders user={user} accessToken={accessToken}>

--- a/apps/web/src/routes/app/_settings.tsx
+++ b/apps/web/src/routes/app/_settings.tsx
@@ -6,6 +6,9 @@ const routeApi = getRouteApi('/app');
 export const Route = createFileRoute('/app/_settings')({
   component: () => {
     const { initialLayout, layoutId, defaultLayout } = routeApi.useLoaderData();
+    console.log('initialLayout', initialLayout);
+    console.log('layoutId', layoutId);
+    console.log('defaultLayout', defaultLayout);
     return (
       <SettingsAppLayout
         initialLayout={initialLayout}

--- a/apps/web/src/routes/app/_settings/settings.index.tsx
+++ b/apps/web/src/routes/app/_settings/settings.index.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/app/_settings/settings/')({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  return <div>Hello "/app/_settings/"!</div>;
+}

--- a/apps/web/src/routes/app/healthcheck.tsx
+++ b/apps/web/src/routes/app/healthcheck.tsx
@@ -1,0 +1,375 @@
+import type { HealthCheckResponse } from '@buster/server-shared/healthcheck';
+import { createFileRoute } from '@tanstack/react-router';
+import { useHealthcheck } from '@/api/buster_rest/healthcheck/queryRequests';
+import { useGetUserBasicInfo } from '@/api/buster_rest/users/useGetUserInfo';
+import type { RustApiError } from '@/api/errors';
+import { useGetSupabaseUser } from '@/context/Supabase';
+
+export const Route = createFileRoute('/app/healthcheck')({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { data, isLoading, error } = useHealthcheck();
+  const supabaseUser = useGetSupabaseUser();
+  const user = useGetUserBasicInfo();
+
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
+  if (error) {
+    return <ErrorState error={error} />;
+  }
+
+  if (!data) {
+    return <ErrorState error={new Error('No data received')} />;
+  }
+
+  return <HealthcheckDashboard data={data} supabaseUser={supabaseUser} user={user} />;
+}
+
+function LoadingState() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-white flex items-center justify-center">
+      <div className="text-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+        <p className="text-gray-600">Checking system health...</p>
+      </div>
+    </div>
+  );
+}
+
+function ErrorState({ error }: { error: Error | RustApiError }) {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-red-50 to-white flex items-center justify-center">
+      <div className="bg-white rounded-lg shadow-lg p-8 max-w-md w-full mx-4">
+        <div className="flex items-center mb-4">
+          <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center mr-4">
+            <svg
+              className="w-6 h-6 text-red-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.732-.833-2.5 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"
+              />
+            </svg>
+          </div>
+          <div>
+            <h2 className="text-xl font-semibold text-gray-900">Health Check Failed</h2>
+            <p className="text-gray-600">Unable to retrieve system status</p>
+          </div>
+        </div>
+        <div className="bg-red-50 border border-red-200 rounded-md p-3">
+          <p className="text-sm text-red-800">{error.message}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HealthcheckDashboard({
+  data,
+  supabaseUser,
+  user,
+}: {
+  data: HealthCheckResponse;
+  supabaseUser: ReturnType<typeof useGetSupabaseUser>;
+  user: ReturnType<typeof useGetUserBasicInfo>;
+}) {
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'healthy':
+      case 'pass':
+        return 'text-green-600 bg-green-100';
+      case 'degraded':
+      case 'warn':
+        return 'text-yellow-600 bg-yellow-100';
+      case 'unhealthy':
+      case 'fail':
+        return 'text-red-600 bg-red-100';
+      default:
+        return 'text-gray-600 bg-gray-100';
+    }
+  };
+
+  const getStatusIcon = (status: string) => {
+    switch (status) {
+      case 'healthy':
+      case 'pass':
+        return (
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+        );
+      case 'degraded':
+      case 'warn':
+        return (
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.732-.833-2.5 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"
+            />
+          </svg>
+        );
+      case 'unhealthy':
+      case 'fail':
+        return (
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        );
+      default:
+        return (
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+        );
+    }
+  };
+
+  const formatUptime = (seconds: number) => {
+    const days = Math.floor(seconds / 86400);
+    const hours = Math.floor((seconds % 86400) / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+
+    if (days > 0) {
+      return `${days}d ${hours}h ${minutes}m`;
+    }
+    if (hours > 0) {
+      return `${hours}h ${minutes}m`;
+    }
+    return `${minutes}m`;
+  };
+
+  const formatTimestamp = (timestamp: string) => {
+    return new Date(timestamp).toLocaleString();
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-white p-6">
+      <div className="max-w-6xl mx-auto">
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">System Health Dashboard</h1>
+          <p className="text-gray-600">Real-time monitoring of system components</p>
+        </div>
+
+        {/* User Data Section */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+          {/* Supabase User Data */}
+          <div className="bg-white rounded-lg shadow-lg p-6">
+            <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center">
+              <div className="w-8 h-8 bg-blue-100 rounded-lg flex items-center justify-center mr-3">
+                <svg
+                  className="w-4 h-4 text-blue-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                  />
+                </svg>
+              </div>
+              Supabase User
+            </h3>
+            <div className="bg-gray-50 rounded-md p-4">
+              <pre className="text-sm text-gray-800 whitespace-pre-wrap overflow-auto">
+                {JSON.stringify(supabaseUser, null, 2)}
+              </pre>
+            </div>
+          </div>
+
+          {/* User Basic Info */}
+          <div className="bg-white rounded-lg shadow-lg p-6">
+            <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center">
+              <div className="w-8 h-8 bg-green-100 rounded-lg flex items-center justify-center mr-3">
+                <svg
+                  className="w-4 h-4 text-green-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                  />
+                </svg>
+              </div>
+              User Basic Info
+            </h3>
+            <div className="bg-gray-50 rounded-md p-4">
+              <pre className="text-sm text-gray-800 whitespace-pre-wrap overflow-auto">
+                {JSON.stringify(user, null, 2)}
+              </pre>
+            </div>
+          </div>
+        </div>
+
+        {/* Overall Status Card */}
+        <div className="bg-white rounded-lg shadow-lg p-6 mb-6">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center">
+              <div
+                className={`w-12 h-12 rounded-full flex items-center justify-center mr-4 ${getStatusColor(
+                  data.status
+                )}`}
+              >
+                {getStatusIcon(data.status)}
+              </div>
+              <div>
+                <h2 className="text-2xl font-semibold text-gray-900 capitalize">{data.status}</h2>
+                <p className="text-gray-600">Overall System Status</p>
+              </div>
+            </div>
+            <div className="text-right">
+              <p className="text-sm text-gray-500">Last checked</p>
+              <p className="text-gray-900 font-medium">{formatTimestamp(data.timestamp)}</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Metrics Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+          <div className="bg-white rounded-lg shadow p-6">
+            <div className="flex items-center">
+              <div className="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center mr-3">
+                <svg
+                  className="w-5 h-5 text-blue-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+              </div>
+              <div>
+                <p className="text-sm text-gray-500">Uptime</p>
+                <p className="text-xl font-semibold text-gray-900">{formatUptime(data.uptime)}</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-lg shadow p-6">
+            <div className="flex items-center">
+              <div className="w-10 h-10 bg-purple-100 rounded-lg flex items-center justify-center mr-3">
+                <svg
+                  className="w-5 h-5 text-purple-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M7 4V2a1 1 0 011-1h8a1 1 0 011 1v2h4a1 1 0 011 1v1a1 1 0 01-1 1h-1v12a2 2 0 01-2 2H6a2 2 0 01-2-2V7H3a1 1 0 01-1-1V5a1 1 0 011-1h4z"
+                  />
+                </svg>
+              </div>
+              <div>
+                <p className="text-sm text-gray-500">Version</p>
+                <p className="text-xl font-semibold text-gray-900">{data.version}</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-lg shadow p-6">
+            <div className="flex items-center">
+              <div className="w-10 h-10 bg-green-100 rounded-lg flex items-center justify-center mr-3">
+                <svg
+                  className="w-5 h-5 text-green-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9v-9m0-9v9"
+                  />
+                </svg>
+              </div>
+              <div>
+                <p className="text-sm text-gray-500">Environment</p>
+                <p className="text-xl font-semibold text-gray-900 capitalize">{data.environment}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Component Checks */}
+        <div className="bg-white rounded-lg shadow-lg p-6">
+          <h3 className="text-xl font-semibold text-gray-900 mb-6">Component Health Checks</h3>
+          <div className="space-y-4">
+            {Object.entries(data.checks).map(([componentName, check]) => (
+              <div key={componentName} className="border border-gray-200 rounded-lg p-4">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center">
+                    <div
+                      className={`w-8 h-8 rounded-full flex items-center justify-center mr-3 ${getStatusColor(
+                        check.status
+                      )}`}
+                    >
+                      {getStatusIcon(check.status)}
+                    </div>
+                    <div>
+                      <h4 className="font-medium text-gray-900 capitalize">{componentName}</h4>
+                      {check.message && <p className="text-sm text-gray-600">{check.message}</p>}
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <span
+                      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium capitalize ${getStatusColor(
+                        check.status
+                      )}`}
+                    >
+                      {check.status}
+                    </span>
+                    {check.responseTime && (
+                      <p className="text-sm text-gray-500 mt-1">{check.responseTime}ms</p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="mt-8 text-center text-gray-500 text-sm">
+          <p>System health is monitored continuously. Data refreshes automatically.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -10,7 +10,8 @@ const config = defineConfig(({ command, mode }) => {
   const isProduction = mode === 'production' || mode === 'staging';
   const isTypecheck = process.argv.includes('--typecheck') || process.env.TYPECHECK === 'true';
   const useChecker = !process.env.VITEST && isBuild;
-  const isLocalBuild = process.argv.includes('--local');
+  const isLocalBuild = process.argv.includes('--local') || mode === 'development';
+  const target = isLocalBuild ? ('bun' as const) : ('cloudflare-module' as const);
 
   return {
     server: { port: 3000 },
@@ -20,7 +21,7 @@ const config = defineConfig(({ command, mode }) => {
       tailwindcss(),
       tanstackStart({
         customViteReactPlugin: true,
-        target: isLocalBuild ? 'bun' : 'cloudflare-module',
+        target,
       }),
       viteReact(),
       useChecker

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@ai-sdk/gateway": "^1.0.18",
+    "@ai-sdk/openai": "2.0.0-beta.16",
     "@ai-sdk/provider": "^2.0.0",
     "@buster/access-controls": "workspace:*",
     "@buster/data-source": "workspace:*",

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -2,3 +2,4 @@ export type { ModelMessage } from 'ai';
 
 export * from './workflows';
 export * from './utils';
+export * from './tasks';

--- a/packages/ai/src/llm/index.ts
+++ b/packages/ai/src/llm/index.ts
@@ -1,2 +1,3 @@
 export * from './haiku-3-5';
 export * from './sonnet-4';
+export * from './gpt-5-nano';

--- a/packages/ai/src/tasks/index.ts
+++ b/packages/ai/src/tasks/index.ts
@@ -1,0 +1,1 @@
+export * from './suggested-prompts/suggested-prompts-task';

--- a/packages/ai/src/tasks/suggested-prompts/suggested-prompts-system-prompt.txt
+++ b/packages/ai/src/tasks/suggested-prompts/suggested-prompts-system-prompt.txt
@@ -1,0 +1,58 @@
+You are an AI agent that generates suggested questions for users of an AI data analyst app. Your goal is to suggest insightful data queries based on available data models and recent user chats.
+
+<input>
+- Data models & documentation: A list of schemas, tables, fields, and descriptions the user can access (e.g., sales data with columns like date, revenue, product_id).
+- Recent chats: Transcripts of the user's recent interactions with the data analyst, showing prior questions and interests.
+</input>
+
+<task>
+Analyze the data models for key themes, relationships, and metrics. Review recent chats for user patterns, unanswered topics, or follow-ups. Generate 4 suggested questions for each of these categories:
+- report: questions that result in a robust report with narrative, like "give me a customer segmentation analysis based on purchasing behavior"
+- dashboard: questions that result in a dashboard, like "create a sales performance dashboard" or "make a dashboard that looks like xyz"
+- visualization: questions that result in a single chart or visualization, like "which product category generates the most profit?"
+- help: questions about capabilities or what the AI can help with, like "what types of analyses can you perform?"
+
+Questions must be:
+- Relevant and actionable for data analysis.
+- Varied: Mix summaries, trends, comparisons, forecasts.
+- Specific: Reference actual models/fields where possible.
+- Novel: Avoid repeating recent chats exactly; build on them.
+- Business-oriented: Use natural language relevant to business users, avoiding any technical terms like table, model, or field names.
+- All lowercase, even at sentence starts.
+- No punctuation except commas if needed, and question marks for actual questions (no periods or other marks).
+- 4-15 words max.
+</task>
+
+<output_format>
+Output only a JSON object with category keys and arrays of strings, like:
+{
+  "report": [
+    "give me a customer segmentation analysis based on purchasing behavior",
+    "analyze our discount strategy impact on sales revenue",
+    "provide a trend analysis of quarterly profits",
+    "evaluate product performance across regions"
+  ],
+  "dashboard": [
+    "create a sales performance dashboard",
+    "make a dashboard for inventory tracking",
+    "build a customer engagement metrics dashboard",
+    "design a revenue forecast dashboard"
+  ],
+  "visualization": [
+    "which product category generates the most profit?",
+    "what is the trend in monthly sales?",
+    "how do customer ages compare by region?",
+    "show top vendors by purchase volume"
+  ],
+  "help": [
+    "what types of analyses can you perform?",
+    "how can you help with data visualization?",
+    "what data models are available for queries?",
+    "can you explain your forecasting capabilities?"
+  ]
+}
+</output_format>
+
+<data_documentation>
+{{DOCUMENTATION}}
+</data_documentation>

--- a/packages/ai/src/tasks/suggested-prompts/suggested-prompts-task.ts
+++ b/packages/ai/src/tasks/suggested-prompts/suggested-prompts-task.ts
@@ -1,0 +1,172 @@
+import type { ModelMessage } from 'ai';
+import { generateObject } from 'ai';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { wrapTraced } from 'braintrust';
+import { z } from 'zod';
+import { GPT5Nano } from '../../llm';
+import { DEFAULT_OPENAI_OPTIONS } from '../../llm/providers/gateway';
+
+// Schema for LLM output
+const SuggestedMessagesOutputSchema = z.object({
+  report: z.array(z.string()).describe('Suggested prompts for generating reports'),
+  dashboard: z.array(z.string()).describe('Suggested prompts for creating dashboards'),
+  visualization: z.array(z.string()).describe('Suggested prompts for creating visualizations'),
+  help: z.array(z.string()).describe('Suggested help prompts for getting assistance'),
+});
+
+export type SuggestedMessagesOutput = z.infer<typeof SuggestedMessagesOutputSchema>;
+
+export interface GenerateSuggestedMessagesParams {
+  chatHistory: ModelMessage[];
+  databaseContext: string;
+  userId: string;
+}
+
+/**
+ * Load the system prompt from the text file
+ */
+function loadSystemPrompt(): string {
+  try {
+    const promptPath = join(__dirname, 'suggested-prompts-system-prompt.txt');
+    return readFileSync(promptPath, 'utf-8');
+  } catch (error) {
+    console.warn('[GenerateSuggestedMessages] Failed to load system prompt file, using fallback');
+    return `You are a business intelligence suggestion engine. Generate 3-5 relevant, actionable prompts for each category (report, dashboard, visualization, help) based on the user's data and chat history.`;
+  }
+}
+
+/**
+ * Generates contextual suggested messages based on chat history and database context
+ */
+export async function generateSuggestedMessages(
+  params: GenerateSuggestedMessagesParams
+): Promise<SuggestedMessagesOutput> {
+  const { chatHistory, databaseContext, userId } = params;
+
+  try {
+    const baseSystemPrompt = loadSystemPrompt();
+    
+    // Combine system prompt with database context
+    const systemPromptWithContext = baseSystemPrompt.replace('{{DOCUMENTATION}}', databaseContext);
+
+    // Format chat history for the user message
+    const chatHistoryText = chatHistory.length > 0 
+      ? chatHistory
+          .slice(-10) // Take last 10 messages to stay within token limits
+          .map((msg, index) => {
+            const role = msg.role.toUpperCase();
+            const content = typeof msg.content === 'string' 
+              ? msg.content 
+              : JSON.stringify(msg.content);
+            return `${index + 1}. ${role}: ${content}`;
+          })
+          .join('\n')
+      : 'No chat history available';
+
+    const userMessage = `Based on this chat history, generate suggested prompts:
+
+<chat_history>
+${chatHistoryText}
+</chat_history>
+
+Generate suggestions that are relevant to the conversation context and available data.`;
+
+    const tracedGeneration = wrapTraced(
+      async () => {
+        const { object } = await generateObject({
+          model: GPT5Nano,
+          schema: SuggestedMessagesOutputSchema,
+          prompt: userMessage,
+          temperature: 1,
+          maxOutputTokens: 2000,
+          system: systemPromptWithContext,
+          providerOptions: DEFAULT_OPENAI_OPTIONS,
+        });
+
+        return object;
+      },
+      {
+        name: 'Generate Suggested Prompts',
+        spanAttributes: {
+          chatHistoryLength: chatHistory.length,
+          userId: userId,
+        },
+      }
+    );
+
+    const suggestions = await tracedGeneration();
+
+    // Validate and limit suggestions per category
+    const validatedSuggestions: SuggestedMessagesOutput = {
+      report: suggestions.report.slice(0, 4),
+      dashboard: suggestions.dashboard.slice(0, 4),
+      visualization: suggestions.visualization.slice(0, 4),
+      help: suggestions.help.slice(0, 4),
+    };
+
+    // Ensure minimum of 2 suggestions per category
+    Object.keys(validatedSuggestions).forEach((key) => {
+      const categoryKey = key as keyof SuggestedMessagesOutput;
+      if (validatedSuggestions[categoryKey].length < 2) {
+        // Add fallback suggestions if we don't have enough
+        const fallbacks = getFallbackSuggestions(categoryKey);
+        validatedSuggestions[categoryKey] = [
+          ...validatedSuggestions[categoryKey],
+          ...fallbacks.slice(0, 2 - validatedSuggestions[categoryKey].length),
+        ];
+      }
+    });
+
+    return validatedSuggestions;
+  } catch (error) {
+    console.error('[GenerateSuggestedMessages] Failed to generate suggestions:', {
+      error: error instanceof Error ? error.message : 'Unknown error',
+      errorType: error instanceof Error ? error.name : 'Unknown',
+      chatHistoryLength: chatHistory.length,
+      userId: userId,
+    });
+
+    // Return fallback suggestions on error
+    return {
+      report: getFallbackSuggestions('report'),
+      dashboard: getFallbackSuggestions('dashboard'),
+      visualization: getFallbackSuggestions('visualization'),
+      help: getFallbackSuggestions('help'),
+    };
+  }
+}
+
+/**
+ * Provides fallback suggestions when AI generation fails or produces insufficient results
+ */
+function getFallbackSuggestions(category: keyof SuggestedMessagesOutput): string[] {
+  const fallbacks = {
+    report: [
+      'Generate a monthly performance summary report',
+      'Create a comparative analysis report for this quarter',
+      'Show me a detailed breakdown of key metrics',
+      'Analyze trends and patterns in recent data',
+    ],
+    dashboard: [
+      'Create a key metrics overview dashboard',
+      'Build a real-time performance monitoring dashboard',
+      'Set up a weekly summary dashboard',
+      'Design an executive summary dashboard',
+    ],
+    visualization: [
+      'Show me a trend chart of recent activity',
+      'Create a comparison chart between categories',
+      'Display the top 10 items in a bar chart',
+      'Generate a pie chart showing distribution',
+    ],
+    help: [
+      'How do I create a new dashboard?',
+      'What types of charts can I create?',
+      'How do I filter my data?',
+      'Show me tips for better data analysis',
+    ],
+  };
+
+  return fallbacks[category] || [];
+}

--- a/packages/database/drizzle/0092_gorgeous_carnage.sql
+++ b/packages/database/drizzle/0092_gorgeous_carnage.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "users" ADD COLUMN "suggested_prompts" jsonb DEFAULT '{
+        "suggestedPrompts": {
+          "report": [],
+          "dashboard": [],
+          "visualization": [],
+          "help": []
+        },
+        "updatedAt": null
+      }'::jsonb NOT NULL;

--- a/packages/database/drizzle/meta/0092_snapshot.json
+++ b/packages/database/drizzle/meta/0092_snapshot.json
@@ -1,0 +1,7042 @@
+{
+  "id": "f2aef937-92ec-4d27-be96-7919d12f6114",
+  "prevId": "ca69431e-0a76-4006-ac7d-9f7ddb3706d3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_organization_id_fkey": {
+          "name": "api_keys_organization_id_fkey",
+          "tableFrom": "api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_owner_id_fkey": {
+          "name": "api_keys_owner_id_fkey",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_key": {
+          "name": "api_keys_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_permissions": {
+      "name": "asset_permissions",
+      "schema": "",
+      "columns": {
+        "identity_id": {
+          "name": "identity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_type": {
+          "name": "identity_type",
+          "type": "identity_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "asset_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "asset_permission_role_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_permissions_created_by_fkey": {
+          "name": "asset_permissions_created_by_fkey",
+          "tableFrom": "asset_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "asset_permissions_updated_by_fkey": {
+          "name": "asset_permissions_updated_by_fkey",
+          "tableFrom": "asset_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "asset_permissions_pkey": {
+          "name": "asset_permissions_pkey",
+          "columns": [
+            "identity_id",
+            "identity_type",
+            "asset_id",
+            "asset_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_search": {
+      "name": "asset_search",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "asset_search_asset_id_asset_type_idx": {
+          "name": "asset_search_asset_id_asset_type_idx",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            },
+            {
+              "expression": "asset_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pgroonga_content_index": {
+          "name": "pgroonga_content_index",
+          "columns": [
+            {
+              "expression": "content",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "pgroonga_text_full_text_search_ops_v2"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "pgroonga",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publicly_accessible": {
+          "name": "publicly_accessible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publicly_enabled_by": {
+          "name": "publicly_enabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_expiry_date": {
+          "name": "public_expiry_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "most_recent_file_id": {
+          "name": "most_recent_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "most_recent_file_type": {
+          "name": "most_recent_file_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "most_recent_version_number": {
+          "name": "most_recent_version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_chat_authorization": {
+          "name": "slack_chat_authorization",
+          "type": "slack_chat_authorization_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_sharing": {
+          "name": "workspace_sharing",
+          "type": "workspace_sharing_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "workspace_sharing_enabled_by": {
+          "name": "workspace_sharing_enabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_sharing_enabled_at": {
+          "name": "workspace_sharing_enabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "chats_created_at_idx": {
+          "name": "chats_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chats_created_by_idx": {
+          "name": "chats_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chats_organization_id_idx": {
+          "name": "chats_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chats_most_recent_file_id": {
+          "name": "idx_chats_most_recent_file_id",
+          "columns": [
+            {
+              "expression": "most_recent_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chats_most_recent_file_type": {
+          "name": "idx_chats_most_recent_file_type",
+          "columns": [
+            {
+              "expression": "most_recent_file_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chats_organization_id_fkey": {
+          "name": "chats_organization_id_fkey",
+          "tableFrom": "chats",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "chats_created_by_fkey": {
+          "name": "chats_created_by_fkey",
+          "tableFrom": "chats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "chats_updated_by_fkey": {
+          "name": "chats_updated_by_fkey",
+          "tableFrom": "chats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "chats_publicly_enabled_by_fkey": {
+          "name": "chats_publicly_enabled_by_fkey",
+          "tableFrom": "chats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "publicly_enabled_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "chats_workspace_sharing_enabled_by_fkey": {
+          "name": "chats_workspace_sharing_enabled_by_fkey",
+          "tableFrom": "chats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "workspace_sharing_enabled_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_sharing": {
+          "name": "workspace_sharing",
+          "type": "workspace_sharing_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "workspace_sharing_enabled_by": {
+          "name": "workspace_sharing_enabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_sharing_enabled_at": {
+          "name": "workspace_sharing_enabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "collections_organization_id_fkey": {
+          "name": "collections_organization_id_fkey",
+          "tableFrom": "collections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "collections_created_by_fkey": {
+          "name": "collections_created_by_fkey",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "collections_updated_by_fkey": {
+          "name": "collections_updated_by_fkey",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "collections_workspace_sharing_enabled_by_fkey": {
+          "name": "collections_workspace_sharing_enabled_by_fkey",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "workspace_sharing_enabled_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collections_to_assets": {
+      "name": "collections_to_assets",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "asset_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "collections_to_assets_created_by_fkey": {
+          "name": "collections_to_assets_created_by_fkey",
+          "tableFrom": "collections_to_assets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "collections_to_assets_updated_by_fkey": {
+          "name": "collections_to_assets_updated_by_fkey",
+          "tableFrom": "collections_to_assets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collections_to_assets_pkey": {
+          "name": "collections_to_assets_pkey",
+          "columns": [
+            "collection_id",
+            "asset_id",
+            "asset_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_files": {
+      "name": "dashboard_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "filter": {
+          "name": "filter",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publicly_accessible": {
+          "name": "publicly_accessible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publicly_enabled_by": {
+          "name": "publicly_enabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_expiry_date": {
+          "name": "public_expiry_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_history": {
+          "name": "version_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "public_password": {
+          "name": "public_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_sharing": {
+          "name": "workspace_sharing",
+          "type": "workspace_sharing_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "workspace_sharing_enabled_by": {
+          "name": "workspace_sharing_enabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_sharing_enabled_at": {
+          "name": "workspace_sharing_enabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dashboard_files_created_by_idx": {
+          "name": "dashboard_files_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboard_files_deleted_at_idx": {
+          "name": "dashboard_files_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboard_files_organization_id_idx": {
+          "name": "dashboard_files_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboard_files_created_by_fkey": {
+          "name": "dashboard_files_created_by_fkey",
+          "tableFrom": "dashboard_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "dashboard_files_publicly_enabled_by_fkey": {
+          "name": "dashboard_files_publicly_enabled_by_fkey",
+          "tableFrom": "dashboard_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "publicly_enabled_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "dashboard_files_workspace_sharing_enabled_by_fkey": {
+          "name": "dashboard_files_workspace_sharing_enabled_by_fkey",
+          "tableFrom": "dashboard_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "workspace_sharing_enabled_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_versions": {
+      "name": "dashboard_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_versions_dashboard_id_fkey": {
+          "name": "dashboard_versions_dashboard_id_fkey",
+          "tableFrom": "dashboard_versions",
+          "tableTo": "dashboards",
+          "columnsFrom": [
+            "dashboard_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboards": {
+      "name": "dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publicly_accessible": {
+          "name": "publicly_accessible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publicly_enabled_by": {
+          "name": "publicly_enabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_expiry_date": {
+          "name": "public_expiry_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_secret_id": {
+          "name": "password_secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboards_publicly_enabled_by_fkey": {
+          "name": "dashboards_publicly_enabled_by_fkey",
+          "tableFrom": "dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "publicly_enabled_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "dashboards_organization_id_fkey": {
+          "name": "dashboards_organization_id_fkey",
+          "tableFrom": "dashboards",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "dashboards_created_by_fkey": {
+          "name": "dashboards_created_by_fkey",
+          "tableFrom": "dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "dashboards_updated_by_fkey": {
+          "name": "dashboards_updated_by_fkey",
+          "tableFrom": "dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_sources": {
+      "name": "data_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "data_source_onboarding_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'notStarted'"
+        },
+        "onboarding_error": {
+          "name": "onboarding_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dev'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "data_sources_organization_id_fkey": {
+          "name": "data_sources_organization_id_fkey",
+          "tableFrom": "data_sources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "data_sources_created_by_fkey": {
+          "name": "data_sources_created_by_fkey",
+          "tableFrom": "data_sources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "data_sources_updated_by_fkey": {
+          "name": "data_sources_updated_by_fkey",
+          "tableFrom": "data_sources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "data_sources_name_organization_id_env_key": {
+          "name": "data_sources_name_organization_id_env_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "organization_id",
+            "env"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.database_metadata": {
+      "name": "database_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "database_metadata_data_source_id_idx": {
+          "name": "database_metadata_data_source_id_idx",
+          "columns": [
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "database_metadata_data_source_id_fkey": {
+          "name": "database_metadata_data_source_id_fkey",
+          "tableFrom": "database_metadata",
+          "tableTo": "data_sources",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "database_metadata_data_source_id_name_key": {
+          "name": "database_metadata_data_source_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "data_source_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dataset_columns": {
+      "name": "dataset_columns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nullable": {
+          "name": "nullable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_values": {
+          "name": "stored_values",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "stored_values_status": {
+          "name": "stored_values_status",
+          "type": "stored_values_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_values_error": {
+          "name": "stored_values_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_values_count": {
+          "name": "stored_values_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_values_last_synced": {
+          "name": "stored_values_last_synced",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semantic_type": {
+          "name": "semantic_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dim_type": {
+          "name": "dim_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expr": {
+          "name": "expr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_dataset_column_name": {
+          "name": "unique_dataset_column_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dataset_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dataset_groups": {
+      "name": "dataset_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dataset_groups_deleted_at_idx": {
+          "name": "dataset_groups_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dataset_groups_organization_id_idx": {
+          "name": "dataset_groups_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dataset_groups_organization_id_fkey": {
+          "name": "dataset_groups_organization_id_fkey",
+          "tableFrom": "dataset_groups",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "dataset_groups_policy": {
+          "name": "dataset_groups_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dataset_groups_permissions": {
+      "name": "dataset_groups_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dataset_group_id": {
+          "name": "dataset_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_type": {
+          "name": "permission_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dataset_groups_permissions_dataset_group_id_idx": {
+          "name": "dataset_groups_permissions_dataset_group_id_idx",
+          "columns": [
+            {
+              "expression": "dataset_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dataset_groups_permissions_organization_id_idx": {
+          "name": "dataset_groups_permissions_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dataset_groups_permissions_permission_id_idx": {
+          "name": "dataset_groups_permissions_permission_id_idx",
+          "columns": [
+            {
+              "expression": "permission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dataset_groups_permissions_dataset_group_id_fkey": {
+          "name": "dataset_groups_permissions_dataset_group_id_fkey",
+          "tableFrom": "dataset_groups_permissions",
+          "tableTo": "dataset_groups",
+          "columnsFrom": [
+            "dataset_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dataset_groups_permissions_organization_id_fkey": {
+          "name": "dataset_groups_permissions_organization_id_fkey",
+          "tableFrom": "dataset_groups_permissions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_dataset_group_permission": {
+          "name": "unique_dataset_group_permission",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dataset_group_id",
+            "permission_id",
+            "permission_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dataset_permissions": {
+      "name": "dataset_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_type": {
+          "name": "permission_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dataset_permissions_dataset_id_idx": {
+          "name": "dataset_permissions_dataset_id_idx",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dataset_permissions_deleted_at_idx": {
+          "name": "dataset_permissions_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dataset_permissions_organization_id_idx": {
+          "name": "dataset_permissions_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dataset_permissions_permission_lookup_idx": {
+          "name": "dataset_permissions_permission_lookup_idx",
+          "columns": [
+            {
+              "expression": "permission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "permission_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dataset_permissions_organization_id_fkey": {
+          "name": "dataset_permissions_organization_id_fkey",
+          "tableFrom": "dataset_permissions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dataset_permissions_dataset_id_fkey": {
+          "name": "dataset_permissions_dataset_id_fkey",
+          "tableFrom": "dataset_permissions",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dataset_permissions_dataset_id_permission_id_permission_typ_key": {
+          "name": "dataset_permissions_dataset_id_permission_id_permission_typ_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dataset_id",
+            "permission_id",
+            "permission_type"
+          ]
+        }
+      },
+      "policies": {
+        "dataset_permissions_policy": {
+          "name": "dataset_permissions_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "dataset_permissions_permission_type_check": {
+          "name": "dataset_permissions_permission_type_check",
+          "value": "(permission_type)::text = ANY ((ARRAY['user'::character varying, 'dataset_group'::character varying, 'permission_group'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.datasets": {
+      "name": "datasets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "database_name": {
+          "name": "database_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "when_to_use": {
+          "name": "when_to_use",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when_not_to_use": {
+          "name": "when_not_to_use",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "dataset_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "imported": {
+          "name": "imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yml_file": {
+          "name": "yml_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "database_identifier": {
+          "name": "database_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "datasets_data_source_id_fkey": {
+          "name": "datasets_data_source_id_fkey",
+          "tableFrom": "datasets",
+          "tableTo": "data_sources",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "datasets_organization_id_fkey": {
+          "name": "datasets_organization_id_fkey",
+          "tableFrom": "datasets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "datasets_created_by_fkey": {
+          "name": "datasets_created_by_fkey",
+          "tableFrom": "datasets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "datasets_updated_by_fkey": {
+          "name": "datasets_updated_by_fkey",
+          "tableFrom": "datasets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "datasets_name_schema_database_identifier_data_source_id_key": {
+          "name": "datasets_name_schema_database_identifier_data_source_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "schema",
+            "database_identifier",
+            "data_source_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.datasets_to_dataset_groups": {
+      "name": "datasets_to_dataset_groups",
+      "schema": "",
+      "columns": {
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dataset_group_id": {
+          "name": "dataset_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "datasets_to_dataset_groups_dataset_group_id_idx": {
+          "name": "datasets_to_dataset_groups_dataset_group_id_idx",
+          "columns": [
+            {
+              "expression": "dataset_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "datasets_to_dataset_groups_dataset_id_fkey": {
+          "name": "datasets_to_dataset_groups_dataset_id_fkey",
+          "tableFrom": "datasets_to_dataset_groups",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "datasets_to_dataset_groups_dataset_group_id_fkey": {
+          "name": "datasets_to_dataset_groups_dataset_group_id_fkey",
+          "tableFrom": "datasets_to_dataset_groups",
+          "tableTo": "dataset_groups",
+          "columnsFrom": [
+            "dataset_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "datasets_to_dataset_groups_pkey": {
+          "name": "datasets_to_dataset_groups_pkey",
+          "columns": [
+            "dataset_id",
+            "dataset_group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "datasets_to_dataset_groups_policy": {
+          "name": "datasets_to_dataset_groups_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.datasets_to_permission_groups": {
+      "name": "datasets_to_permission_groups",
+      "schema": "",
+      "columns": {
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_group_id": {
+          "name": "permission_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "datasets_to_permission_groups_dataset_id_fkey": {
+          "name": "datasets_to_permission_groups_dataset_id_fkey",
+          "tableFrom": "datasets_to_permission_groups",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "datasets_to_permission_groups_permission_group_id_fkey": {
+          "name": "datasets_to_permission_groups_permission_group_id_fkey",
+          "tableFrom": "datasets_to_permission_groups",
+          "tableTo": "permission_groups",
+          "columnsFrom": [
+            "permission_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "datasets_to_permission_groups_pkey": {
+          "name": "datasets_to_permission_groups_pkey",
+          "columns": [
+            "dataset_id",
+            "permission_group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "datasets_to_permission_groups_policy": {
+          "name": "datasets_to_permission_groups_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.__diesel_schema_migrations": {
+      "name": "__diesel_schema_migrations",
+      "schema": "",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_on": {
+          "name": "run_on",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "diesel_schema_migrations_policy": {
+          "name": "diesel_schema_migrations_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_relationship": {
+      "name": "entity_relationship",
+      "schema": "",
+      "columns": {
+        "primary_dataset_id": {
+          "name": "primary_dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "foreign_dataset_id": {
+          "name": "foreign_dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship_type": {
+          "name": "relationship_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "entity_relationship_pkey": {
+          "name": "entity_relationship_pkey",
+          "columns": [
+            "primary_dataset_id",
+            "foreign_dataset_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_integrations": {
+      "name": "github_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_org_id": {
+          "name": "github_org_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_org_name": {
+          "name": "github_org_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_vault_key": {
+          "name": "token_vault_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret_vault_key": {
+          "name": "webhook_secret_vault_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_permissions": {
+          "name": "repository_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "github_integration_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_github_integrations_org_id": {
+          "name": "idx_github_integrations_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_integrations_installation_id": {
+          "name": "idx_github_integrations_installation_id",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_integrations_github_org_id": {
+          "name": "idx_github_integrations_github_org_id",
+          "columns": [
+            {
+              "expression": "github_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_integrations_organization_id_fkey": {
+          "name": "github_integrations_organization_id_fkey",
+          "tableFrom": "github_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_integrations_user_id_fkey": {
+          "name": "github_integrations_user_id_fkey",
+          "tableFrom": "github_integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "github_integrations_token_vault_key_unique": {
+          "name": "github_integrations_token_vault_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_vault_key"
+          ]
+        },
+        "github_integrations_org_installation_key": {
+          "name": "github_integrations_org_installation_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "installation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_message": {
+          "name": "request_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_messages": {
+          "name": "response_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_llm_messages": {
+          "name": "raw_llm_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "final_reasoning_message": {
+          "name": "final_reasoning_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_completed": {
+          "name": "is_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "post_processing_message": {
+          "name": "post_processing_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_run_id": {
+          "name": "trigger_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messages_chat_id_idx": {
+          "name": "messages_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_created_at_idx": {
+          "name": "messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_created_by_idx": {
+          "name": "messages_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_deleted_at_idx": {
+          "name": "messages_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_raw_llm_messages_gin_idx": {
+          "name": "messages_raw_llm_messages_gin_idx",
+          "columns": [
+            {
+              "expression": "raw_llm_messages",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "jsonb_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "messages_response_messages_gin_idx": {
+          "name": "messages_response_messages_gin_idx",
+          "columns": [
+            {
+              "expression": "response_messages",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "jsonb_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "messages_reasoning_gin_idx": {
+          "name": "messages_reasoning_gin_idx",
+          "columns": [
+            {
+              "expression": "reasoning",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "jsonb_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "messages_id_deleted_at_idx": {
+          "name": "messages_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_fkey": {
+          "name": "messages_chat_id_fkey",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messages_created_by_fkey": {
+          "name": "messages_created_by_fkey",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages_deprecated": {
+      "name": "messages_deprecated",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_by": {
+          "name": "sent_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responses": {
+          "name": "responses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "message_feedback_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification": {
+          "name": "verification",
+          "type": "verification_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'notRequested'"
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chart_config": {
+          "name": "chart_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "chart_recommendations": {
+          "name": "chart_recommendations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "time_frame": {
+          "name": "time_frame",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_metadata": {
+          "name": "data_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_session_id": {
+          "name": "draft_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_state": {
+          "name": "draft_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_question": {
+          "name": "summary_question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sql_evaluation_id": {
+          "name": "sql_evaluation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_sent_by_fkey": {
+          "name": "messages_sent_by_fkey",
+          "tableFrom": "messages_deprecated",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sent_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "messages_dataset_id_fkey": {
+          "name": "messages_dataset_id_fkey",
+          "tableFrom": "messages_deprecated",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_deprecated_sent_by_fkey": {
+          "name": "messages_deprecated_sent_by_fkey",
+          "tableFrom": "messages_deprecated",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sent_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages_to_files": {
+      "name": "messages_to_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_duplicate": {
+          "name": "is_duplicate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "messages_files_file_id_idx": {
+          "name": "messages_files_file_id_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_files_message_id_idx": {
+          "name": "messages_files_message_id_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_to_files_message_id_fkey": {
+          "name": "messages_to_files_message_id_fkey",
+          "tableFrom": "messages_to_files",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "messages_to_files_message_id_file_id_key": {
+          "name": "messages_to_files_message_id_file_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id",
+            "file_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages_to_slack_messages": {
+      "name": "messages_to_slack_messages",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_message_id": {
+          "name": "slack_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messages_to_slack_messages_message_id_idx": {
+          "name": "messages_to_slack_messages_message_id_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_to_slack_messages_slack_message_id_idx": {
+          "name": "messages_to_slack_messages_slack_message_id_idx",
+          "columns": [
+            {
+              "expression": "slack_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_to_slack_messages_message_id_fkey": {
+          "name": "messages_to_slack_messages_message_id_fkey",
+          "tableFrom": "messages_to_slack_messages",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_to_slack_messages_slack_message_id_fkey": {
+          "name": "messages_to_slack_messages_slack_message_id_fkey",
+          "tableFrom": "messages_to_slack_messages",
+          "tableTo": "slack_message_tracking",
+          "columnsFrom": [
+            "slack_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "messages_to_slack_messages_pkey": {
+          "name": "messages_to_slack_messages_pkey",
+          "columns": [
+            "message_id",
+            "slack_message_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metric_files": {
+      "name": "metric_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification": {
+          "name": "verification",
+          "type": "verification_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'notRequested'"
+        },
+        "evaluation_obj": {
+          "name": "evaluation_obj",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_summary": {
+          "name": "evaluation_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_score": {
+          "name": "evaluation_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publicly_accessible": {
+          "name": "publicly_accessible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publicly_enabled_by": {
+          "name": "publicly_enabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_expiry_date": {
+          "name": "public_expiry_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_history": {
+          "name": "version_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "data_metadata": {
+          "name": "data_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_password": {
+          "name": "public_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_sharing": {
+          "name": "workspace_sharing",
+          "type": "workspace_sharing_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "workspace_sharing_enabled_by": {
+          "name": "workspace_sharing_enabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_sharing_enabled_at": {
+          "name": "workspace_sharing_enabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "metric_files_created_by_idx": {
+          "name": "metric_files_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_files_data_metadata_idx": {
+          "name": "metric_files_data_metadata_idx",
+          "columns": [
+            {
+              "expression": "data_metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "jsonb_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "metric_files_deleted_at_idx": {
+          "name": "metric_files_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_files_organization_id_idx": {
+          "name": "metric_files_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metric_files_created_by_fkey": {
+          "name": "metric_files_created_by_fkey",
+          "tableFrom": "metric_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "metric_files_publicly_enabled_by_fkey": {
+          "name": "metric_files_publicly_enabled_by_fkey",
+          "tableFrom": "metric_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "publicly_enabled_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "fk_data_source": {
+          "name": "fk_data_source",
+          "tableFrom": "metric_files",
+          "tableTo": "data_sources",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "metric_files_workspace_sharing_enabled_by_fkey": {
+          "name": "metric_files_workspace_sharing_enabled_by_fkey",
+          "tableFrom": "metric_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "workspace_sharing_enabled_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metric_files_to_dashboard_files": {
+      "name": "metric_files_to_dashboard_files",
+      "schema": "",
+      "columns": {
+        "metric_file_id": {
+          "name": "metric_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dashboard_file_id": {
+          "name": "dashboard_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "metric_files_to_dashboard_files_dashboard_id_idx": {
+          "name": "metric_files_to_dashboard_files_dashboard_id_idx",
+          "columns": [
+            {
+              "expression": "dashboard_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_files_to_dashboard_files_deleted_at_idx": {
+          "name": "metric_files_to_dashboard_files_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_files_to_dashboard_files_metric_id_idx": {
+          "name": "metric_files_to_dashboard_files_metric_id_idx",
+          "columns": [
+            {
+              "expression": "metric_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metric_files_to_dashboard_files_metric_file_id_fkey": {
+          "name": "metric_files_to_dashboard_files_metric_file_id_fkey",
+          "tableFrom": "metric_files_to_dashboard_files",
+          "tableTo": "metric_files",
+          "columnsFrom": [
+            "metric_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "metric_files_to_dashboard_files_dashboard_file_id_fkey": {
+          "name": "metric_files_to_dashboard_files_dashboard_file_id_fkey",
+          "tableFrom": "metric_files_to_dashboard_files",
+          "tableTo": "dashboard_files",
+          "columnsFrom": [
+            "dashboard_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "metric_files_to_dashboard_files_created_by_fkey": {
+          "name": "metric_files_to_dashboard_files_created_by_fkey",
+          "tableFrom": "metric_files_to_dashboard_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "metric_files_to_dashboard_files_pkey": {
+          "name": "metric_files_to_dashboard_files_pkey",
+          "columns": [
+            "metric_file_id",
+            "dashboard_file_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metric_files_to_datasets": {
+      "name": "metric_files_to_datasets",
+      "schema": "",
+      "columns": {
+        "metric_file_id": {
+          "name": "metric_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_version_number": {
+          "name": "metric_version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_metric_file": {
+          "name": "fk_metric_file",
+          "tableFrom": "metric_files_to_datasets",
+          "tableTo": "metric_files",
+          "columnsFrom": [
+            "metric_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_dataset": {
+          "name": "fk_dataset",
+          "tableFrom": "metric_files_to_datasets",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "metric_files_to_datasets_pkey": {
+          "name": "metric_files_to_datasets_pkey",
+          "columns": [
+            "metric_file_id",
+            "dataset_id",
+            "metric_version_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_required": {
+          "name": "payment_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "domains": {
+          "name": "domains",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restrict_new_user_invitations": {
+          "name": "restrict_new_user_invitations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_role": {
+          "name": "default_role",
+          "type": "user_organization_role_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted_querier'"
+        },
+        "organization_color_palettes": {
+          "name": "organization_color_palettes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"selectedId\": null, \"palettes\": [], \"selectedDictionaryPalette\": null}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_name_key": {
+          "name": "organizations_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permission_groups": {
+      "name": "permission_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "permission_groups_organization_id_fkey": {
+          "name": "permission_groups_organization_id_fkey",
+          "tableFrom": "permission_groups",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "permission_groups_created_by_fkey": {
+          "name": "permission_groups_created_by_fkey",
+          "tableFrom": "permission_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "permission_groups_updated_by_fkey": {
+          "name": "permission_groups_updated_by_fkey",
+          "tableFrom": "permission_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permission_groups_to_identities": {
+      "name": "permission_groups_to_identities",
+      "schema": "",
+      "columns": {
+        "permission_group_id": {
+          "name": "permission_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_id": {
+          "name": "identity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_type": {
+          "name": "identity_type",
+          "type": "identity_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "permission_groups_to_identities_created_by_fkey": {
+          "name": "permission_groups_to_identities_created_by_fkey",
+          "tableFrom": "permission_groups_to_identities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "permission_groups_to_identities_updated_by_fkey": {
+          "name": "permission_groups_to_identities_updated_by_fkey",
+          "tableFrom": "permission_groups_to_identities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "permission_groups_to_identities_pkey": {
+          "name": "permission_groups_to_identities_pkey",
+          "columns": [
+            "permission_group_id",
+            "identity_id",
+            "identity_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permission_groups_to_users": {
+      "name": "permission_groups_to_users",
+      "schema": "",
+      "columns": {
+        "permission_group_id": {
+          "name": "permission_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "permission_groups_to_users_user_id_idx": {
+          "name": "permission_groups_to_users_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permission_groups_to_users_permission_group_id_fkey": {
+          "name": "permission_groups_to_users_permission_group_id_fkey",
+          "tableFrom": "permission_groups_to_users",
+          "tableTo": "permission_groups",
+          "columnsFrom": [
+            "permission_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "permission_groups_to_users_user_id_fkey": {
+          "name": "permission_groups_to_users_user_id_fkey",
+          "tableFrom": "permission_groups_to_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "permission_groups_to_users_pkey": {
+          "name": "permission_groups_to_users_pkey",
+          "columns": [
+            "permission_group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "permission_groups_to_users_policy": {
+          "name": "permission_groups_to_users_policy",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_files": {
+      "name": "report_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publicly_accessible": {
+          "name": "publicly_accessible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publicly_enabled_by": {
+          "name": "publicly_enabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_expiry_date": {
+          "name": "public_expiry_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_history": {
+          "name": "version_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "public_password": {
+          "name": "public_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_sharing": {
+          "name": "workspace_sharing",
+          "type": "workspace_sharing_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "workspace_sharing_enabled_by": {
+          "name": "workspace_sharing_enabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_sharing_enabled_at": {
+          "name": "workspace_sharing_enabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "report_files_created_by_idx": {
+          "name": "report_files_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_files_deleted_at_idx": {
+          "name": "report_files_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_files_organization_id_idx": {
+          "name": "report_files_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_files_created_by_fkey": {
+          "name": "report_files_created_by_fkey",
+          "tableFrom": "report_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "report_files_publicly_enabled_by_fkey": {
+          "name": "report_files_publicly_enabled_by_fkey",
+          "tableFrom": "report_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "publicly_enabled_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "report_files_workspace_sharing_enabled_by_fkey": {
+          "name": "report_files_workspace_sharing_enabled_by_fkey",
+          "tableFrom": "report_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "workspace_sharing_enabled_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "report_files_organization_id_fkey": {
+          "name": "report_files_organization_id_fkey",
+          "tableFrom": "report_files",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.s3_integrations": {
+      "name": "s3_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "storage_provider_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_s3_integrations_organization_id": {
+          "name": "idx_s3_integrations_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_s3_integrations_deleted_at": {
+          "name": "idx_s3_integrations_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "s3_integrations_organization_id_fkey": {
+          "name": "s3_integrations_organization_id_fkey",
+          "tableFrom": "s3_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schema_metadata": {
+      "name": "schema_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "database_id": {
+          "name": "database_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "database_name": {
+          "name": "database_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "schema_metadata_data_source_id_idx": {
+          "name": "schema_metadata_data_source_id_idx",
+          "columns": [
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schema_metadata_database_id_idx": {
+          "name": "schema_metadata_database_id_idx",
+          "columns": [
+            {
+              "expression": "database_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schema_metadata_data_source_id_fkey": {
+          "name": "schema_metadata_data_source_id_fkey",
+          "tableFrom": "schema_metadata",
+          "tableTo": "data_sources",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schema_metadata_database_id_fkey": {
+          "name": "schema_metadata_database_id_fkey",
+          "tableFrom": "schema_metadata",
+          "tableTo": "database_metadata",
+          "columnsFrom": [
+            "database_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "schema_metadata_data_source_id_database_id_name_key": {
+          "name": "schema_metadata_data_source_id_database_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "data_source_id",
+            "database_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_integrations": {
+      "name": "slack_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_state": {
+          "name": "oauth_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_expires_at": {
+          "name": "oauth_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_metadata": {
+          "name": "oauth_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_domain": {
+          "name": "team_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enterprise_id": {
+          "name": "enterprise_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_vault_key": {
+          "name": "token_vault_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_slack_user_id": {
+          "name": "installed_by_slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "slack_integration_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "default_channel": {
+          "name": "default_channel",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_sharing_permissions": {
+          "name": "default_sharing_permissions",
+          "type": "slack_sharing_permission_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'shareWithChannel'"
+        }
+      },
+      "indexes": {
+        "idx_slack_integrations_org_id": {
+          "name": "idx_slack_integrations_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_integrations_team_id": {
+          "name": "idx_slack_integrations_team_id",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_integrations_oauth_state": {
+          "name": "idx_slack_integrations_oauth_state",
+          "columns": [
+            {
+              "expression": "oauth_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_integrations_oauth_expires": {
+          "name": "idx_slack_integrations_oauth_expires",
+          "columns": [
+            {
+              "expression": "oauth_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_integrations_organization_id_fkey": {
+          "name": "slack_integrations_organization_id_fkey",
+          "tableFrom": "slack_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_integrations_user_id_fkey": {
+          "name": "slack_integrations_user_id_fkey",
+          "tableFrom": "slack_integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_integrations_oauth_state_unique": {
+          "name": "slack_integrations_oauth_state_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oauth_state"
+          ]
+        },
+        "slack_integrations_token_vault_key_unique": {
+          "name": "slack_integrations_token_vault_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_vault_key"
+          ]
+        },
+        "slack_integrations_org_team_key": {
+          "name": "slack_integrations_org_team_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "slack_integrations_status_check": {
+          "name": "slack_integrations_status_check",
+          "value": "(status = 'pending' AND oauth_state IS NOT NULL) OR (status != 'pending' AND team_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_message_tracking": {
+      "name": "slack_message_tracking",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_message_id": {
+          "name": "internal_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_info": {
+          "name": "sender_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_message_tracking_integration": {
+          "name": "idx_message_tracking_integration",
+          "columns": [
+            {
+              "expression": "integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_tracking_channel": {
+          "name": "idx_message_tracking_channel",
+          "columns": [
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_tracking_thread": {
+          "name": "idx_message_tracking_thread",
+          "columns": [
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_message_tracking_integration_id_fkey": {
+          "name": "slack_message_tracking_integration_id_fkey",
+          "tableFrom": "slack_message_tracking",
+          "tableTo": "slack_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_message_tracking_internal_message_id_unique": {
+          "name": "slack_message_tracking_internal_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "internal_message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sql_evaluations": {
+      "name": "sql_evaluations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "evaluation_obj": {
+          "name": "evaluation_obj",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluation_summary": {
+          "name": "evaluation_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stored_values_sync_jobs": {
+      "name": "stored_values_sync_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "database_name": {
+          "name": "database_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_name": {
+          "name": "schema_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_name": {
+          "name": "column_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_stored_values_sync_jobs_data_source_id": {
+          "name": "idx_stored_values_sync_jobs_data_source_id",
+          "columns": [
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stored_values_sync_jobs_db_schema_table_column": {
+          "name": "idx_stored_values_sync_jobs_db_schema_table_column",
+          "columns": [
+            {
+              "expression": "database_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            },
+            {
+              "expression": "schema_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            },
+            {
+              "expression": "table_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            },
+            {
+              "expression": "column_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stored_values_sync_jobs_status": {
+          "name": "idx_stored_values_sync_jobs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stored_values_sync_jobs_data_source_id_fkey": {
+          "name": "stored_values_sync_jobs_data_source_id_fkey",
+          "tableFrom": "stored_values_sync_jobs",
+          "tableTo": "data_sources",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.table_metadata": {
+      "name": "table_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "database_id": {
+          "name": "database_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_id": {
+          "name": "schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_name": {
+          "name": "schema_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "database_name": {
+          "name": "database_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "table_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clustering_keys": {
+          "name": "clustering_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "table_metadata_data_source_id_idx": {
+          "name": "table_metadata_data_source_id_idx",
+          "columns": [
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "table_metadata_database_id_idx": {
+          "name": "table_metadata_database_id_idx",
+          "columns": [
+            {
+              "expression": "database_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "table_metadata_schema_id_idx": {
+          "name": "table_metadata_schema_id_idx",
+          "columns": [
+            {
+              "expression": "schema_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "table_metadata_data_source_id_fkey": {
+          "name": "table_metadata_data_source_id_fkey",
+          "tableFrom": "table_metadata",
+          "tableTo": "data_sources",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "table_metadata_database_id_fkey": {
+          "name": "table_metadata_database_id_fkey",
+          "tableFrom": "table_metadata",
+          "tableTo": "database_metadata",
+          "columnsFrom": [
+            "database_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "table_metadata_schema_id_fkey": {
+          "name": "table_metadata_schema_id_fkey",
+          "tableFrom": "table_metadata",
+          "tableTo": "schema_metadata",
+          "columnsFrom": [
+            "schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "table_metadata_data_source_id_schema_id_name_key": {
+          "name": "table_metadata_data_source_id_schema_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "data_source_id",
+            "schema_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sharing_setting": {
+          "name": "sharing_setting",
+          "type": "sharing_setting_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "edit_sql": {
+          "name": "edit_sql",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "upload_csv": {
+          "name": "upload_csv",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "export_assets": {
+          "name": "export_assets",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_slack_enabled": {
+          "name": "email_slack_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_organization_id_fkey": {
+          "name": "teams_organization_id_fkey",
+          "tableFrom": "teams",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "teams_created_by_fkey": {
+          "name": "teams_created_by_fkey",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_name_key": {
+          "name": "teams_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams_to_users": {
+      "name": "teams_to_users",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "team_role_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_to_users_team_id_fkey": {
+          "name": "teams_to_users_team_id_fkey",
+          "tableFrom": "teams_to_users",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "teams_to_users_user_id_fkey": {
+          "name": "teams_to_users_user_id_fkey",
+          "tableFrom": "teams_to_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "teams_to_users_pkey": {
+          "name": "teams_to_users_pkey",
+          "columns": [
+            "team_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.terms": {
+      "name": "terms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sql_snippet": {
+          "name": "sql_snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "terms_organization_id_fkey": {
+          "name": "terms_organization_id_fkey",
+          "tableFrom": "terms",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terms_created_by_fkey": {
+          "name": "terms_created_by_fkey",
+          "tableFrom": "terms",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "terms_updated_by_fkey": {
+          "name": "terms_updated_by_fkey",
+          "tableFrom": "terms",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.terms_to_datasets": {
+      "name": "terms_to_datasets",
+      "schema": "",
+      "columns": {
+        "term_id": {
+          "name": "term_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "terms_to_datasets_term_id_fkey": {
+          "name": "terms_to_datasets_term_id_fkey",
+          "tableFrom": "terms_to_datasets",
+          "tableTo": "terms",
+          "columnsFrom": [
+            "term_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terms_to_datasets_dataset_id_fkey": {
+          "name": "terms_to_datasets_dataset_id_fkey",
+          "tableFrom": "terms_to_datasets",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "terms_to_datasets_pkey": {
+          "name": "terms_to_datasets_pkey",
+          "columns": [
+            "term_id",
+            "dataset_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.threads_deprecated": {
+      "name": "threads_deprecated",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publicly_accessible": {
+          "name": "publicly_accessible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publicly_enabled_by": {
+          "name": "publicly_enabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_expiry_date": {
+          "name": "public_expiry_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_secret_id": {
+          "name": "password_secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_message_id": {
+          "name": "state_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_thread_id": {
+          "name": "parent_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "threads_created_by_fkey": {
+          "name": "threads_created_by_fkey",
+          "tableFrom": "threads_deprecated",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "threads_updated_by_fkey": {
+          "name": "threads_updated_by_fkey",
+          "tableFrom": "threads_deprecated",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "threads_publicly_enabled_by_fkey": {
+          "name": "threads_publicly_enabled_by_fkey",
+          "tableFrom": "threads_deprecated",
+          "tableTo": "users",
+          "columnsFrom": [
+            "publicly_enabled_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "threads_parent_thread_id_fkey": {
+          "name": "threads_parent_thread_id_fkey",
+          "tableFrom": "threads_deprecated",
+          "tableTo": "threads_deprecated",
+          "columnsFrom": [
+            "parent_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "threads_organization_id_fkey": {
+          "name": "threads_organization_id_fkey",
+          "tableFrom": "threads_deprecated",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "threads_deprecated_created_by_fkey": {
+          "name": "threads_deprecated_created_by_fkey",
+          "tableFrom": "threads_deprecated",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "threads_deprecated_updated_by_fkey": {
+          "name": "threads_deprecated_updated_by_fkey",
+          "tableFrom": "threads_deprecated",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "threads_deprecated_publicly_enabled_by_fkey": {
+          "name": "threads_deprecated_publicly_enabled_by_fkey",
+          "tableFrom": "threads_deprecated",
+          "tableTo": "users",
+          "columnsFrom": [
+            "publicly_enabled_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.threads_to_dashboards": {
+      "name": "threads_to_dashboards",
+      "schema": "",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "threads_to_dashboards_thread_id_fkey": {
+          "name": "threads_to_dashboards_thread_id_fkey",
+          "tableFrom": "threads_to_dashboards",
+          "tableTo": "threads_deprecated",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "threads_to_dashboards_dashboard_id_fkey": {
+          "name": "threads_to_dashboards_dashboard_id_fkey",
+          "tableFrom": "threads_to_dashboards",
+          "tableTo": "dashboards",
+          "columnsFrom": [
+            "dashboard_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "threads_to_dashboards_added_by_fkey": {
+          "name": "threads_to_dashboards_added_by_fkey",
+          "tableFrom": "threads_to_dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "threads_to_dashboards_pkey": {
+          "name": "threads_to_dashboards_pkey",
+          "columns": [
+            "thread_id",
+            "dashboard_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "asset_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_favorites_user_id_fkey": {
+          "name": "user_favorites_user_id_fkey",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_favorites_pkey": {
+          "name": "user_favorites_pkey",
+          "columns": [
+            "user_id",
+            "asset_id",
+            "asset_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_prompts": {
+          "name": "suggested_prompts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\n        \"suggestedPrompts\": {\n          \"report\": [],\n          \"dashboard\": [],\n          \"visualization\": [],\n          \"help\": []\n        },\n        \"updatedAt\": null\n      }'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_key": {
+          "name": "users_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_to_organizations": {
+      "name": "users_to_organizations",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_organization_role_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'querier'"
+        },
+        "sharing_setting": {
+          "name": "sharing_setting",
+          "type": "sharing_setting_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "edit_sql": {
+          "name": "edit_sql",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "upload_csv": {
+          "name": "upload_csv",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "export_assets": {
+          "name": "export_assets",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_slack_enabled": {
+          "name": "email_slack_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "user_organization_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_to_organizations_organization_id_fkey": {
+          "name": "users_to_organizations_organization_id_fkey",
+          "tableFrom": "users_to_organizations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_to_organizations_user_id_fkey": {
+          "name": "users_to_organizations_user_id_fkey",
+          "tableFrom": "users_to_organizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "users_to_organizations_created_by_fkey": {
+          "name": "users_to_organizations_created_by_fkey",
+          "tableFrom": "users_to_organizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "users_to_organizations_updated_by_fkey": {
+          "name": "users_to_organizations_updated_by_fkey",
+          "tableFrom": "users_to_organizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "users_to_organizations_deleted_by_fkey": {
+          "name": "users_to_organizations_deleted_by_fkey",
+          "tableFrom": "users_to_organizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_to_organizations_pkey": {
+          "name": "users_to_organizations_pkey",
+          "columns": [
+            "user_id",
+            "organization_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.asset_permission_role_enum": {
+      "name": "asset_permission_role_enum",
+      "schema": "public",
+      "values": [
+        "owner",
+        "viewer",
+        "full_access",
+        "can_edit",
+        "can_filter",
+        "can_view"
+      ]
+    },
+    "public.asset_type_enum": {
+      "name": "asset_type_enum",
+      "schema": "public",
+      "values": [
+        "dashboard",
+        "thread",
+        "collection",
+        "chat",
+        "metric_file",
+        "dashboard_file",
+        "report_file",
+        "data_source",
+        "metric",
+        "filter",
+        "dataset",
+        "tool",
+        "source",
+        "collection_file",
+        "dataset_permission"
+      ]
+    },
+    "public.data_source_onboarding_status_enum": {
+      "name": "data_source_onboarding_status_enum",
+      "schema": "public",
+      "values": [
+        "notStarted",
+        "inProgress",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.dataset_type_enum": {
+      "name": "dataset_type_enum",
+      "schema": "public",
+      "values": [
+        "table",
+        "view",
+        "materializedView"
+      ]
+    },
+    "public.github_integration_status_enum": {
+      "name": "github_integration_status_enum",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "suspended",
+        "revoked"
+      ]
+    },
+    "public.identity_type_enum": {
+      "name": "identity_type_enum",
+      "schema": "public",
+      "values": [
+        "user",
+        "team",
+        "organization"
+      ]
+    },
+    "public.message_feedback_enum": {
+      "name": "message_feedback_enum",
+      "schema": "public",
+      "values": [
+        "positive",
+        "negative"
+      ]
+    },
+    "public.sharing_setting_enum": {
+      "name": "sharing_setting_enum",
+      "schema": "public",
+      "values": [
+        "none",
+        "team",
+        "organization",
+        "public"
+      ]
+    },
+    "public.slack_chat_authorization_enum": {
+      "name": "slack_chat_authorization_enum",
+      "schema": "public",
+      "values": [
+        "unauthorized",
+        "authorized",
+        "auto_added"
+      ]
+    },
+    "public.slack_integration_status_enum": {
+      "name": "slack_integration_status_enum",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "failed",
+        "revoked"
+      ]
+    },
+    "public.slack_sharing_permission_enum": {
+      "name": "slack_sharing_permission_enum",
+      "schema": "public",
+      "values": [
+        "shareWithWorkspace",
+        "shareWithChannel",
+        "noSharing"
+      ]
+    },
+    "public.storage_provider_enum": {
+      "name": "storage_provider_enum",
+      "schema": "public",
+      "values": [
+        "s3",
+        "r2",
+        "gcs"
+      ]
+    },
+    "public.stored_values_status_enum": {
+      "name": "stored_values_status_enum",
+      "schema": "public",
+      "values": [
+        "syncing",
+        "success",
+        "failed"
+      ]
+    },
+    "public.table_type_enum": {
+      "name": "table_type_enum",
+      "schema": "public",
+      "values": [
+        "TABLE",
+        "VIEW",
+        "MATERIALIZED_VIEW",
+        "EXTERNAL_TABLE",
+        "TEMPORARY_TABLE"
+      ]
+    },
+    "public.team_role_enum": {
+      "name": "team_role_enum",
+      "schema": "public",
+      "values": [
+        "manager",
+        "member"
+      ]
+    },
+    "public.user_organization_role_enum": {
+      "name": "user_organization_role_enum",
+      "schema": "public",
+      "values": [
+        "workspace_admin",
+        "data_admin",
+        "querier",
+        "restricted_querier",
+        "viewer"
+      ]
+    },
+    "public.user_organization_status_enum": {
+      "name": "user_organization_status_enum",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "pending",
+        "guest"
+      ]
+    },
+    "public.verification_enum": {
+      "name": "verification_enum",
+      "schema": "public",
+      "values": [
+        "verified",
+        "backlogged",
+        "inReview",
+        "requested",
+        "notRequested"
+      ]
+    },
+    "public.workspace_sharing_enum": {
+      "name": "workspace_sharing_enum",
+      "schema": "public",
+      "values": [
+        "none",
+        "can_view",
+        "can_edit",
+        "full_access"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -645,6 +645,13 @@
       "when": 1756995817124,
       "tag": "0091_fine_sinister_six",
       "breakpoints": true
+    },
+    {
+      "idx": 92,
+      "version": "7",
+      "when": 1757456831192,
+      "tag": "0092_gorgeous_carnage",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/queries/messages/index.ts
+++ b/packages/database/src/queries/messages/index.ts
@@ -3,3 +3,4 @@ export * from './messages';
 export * from './chatConversationHistory';
 export * from './messageContext';
 export * from './update-message-entries';
+export * from './user-recent-messages';

--- a/packages/database/src/queries/messages/user-recent-messages.ts
+++ b/packages/database/src/queries/messages/user-recent-messages.ts
@@ -1,0 +1,64 @@
+import { and, desc, eq, isNull } from 'drizzle-orm';
+import { z } from 'zod';
+import { db } from '../../index';
+import { messages } from '../../schema';
+
+// Schema for the return type
+export const UserRecentMessageSchema = z.object({
+  id: z.string().uuid(),
+  requestMessage: z.string(),
+  responseMessages: z.string(),
+  createdAt: z.string(),
+});
+
+export type UserRecentMessage = z.infer<typeof UserRecentMessageSchema>;
+
+/**
+ * Get the most recent 15 messages created by a specific user
+ * @param userId - The ID of the user to get messages for
+ * @param count - The number of messages to get
+ * @returns Array of recent messages with request and response data
+ */
+export async function getUserRecentMessages(
+  userId: string,
+  count = 15
+): Promise<UserRecentMessage[]> {
+  const result = await db
+    .select({
+      id: messages.id,
+      requestMessage: messages.requestMessage,
+      responseMessages: messages.responseMessages,
+      createdAt: messages.createdAt,
+    })
+    .from(messages)
+    .where(
+      and(
+        // Only get messages created by the user and not soft deleted
+        eq(messages.createdBy, userId),
+        isNull(messages.deletedAt)
+      )
+    )
+    .orderBy(desc(messages.createdAt))
+    .limit(count);
+
+  return result.map((msg: (typeof result)[0]) => ({
+    id: msg.id,
+    requestMessage: msg.requestMessage ?? '',
+    responseMessages: JSON.stringify(msg.responseMessages),
+    createdAt: msg.createdAt,
+  }));
+}
+
+/**
+ * Get the most recent messages created by a specific user with validation
+ * @param userId - The ID of the user to get messages for
+ * @param count - The number of messages to get
+ * @returns Array of validated recent messages
+ */
+export async function getUserRecentMessagesValidated(
+  userId: string,
+  count = 15
+): Promise<UserRecentMessage[]> {
+  const messages = await getUserRecentMessages(userId, count);
+  return z.array(UserRecentMessageSchema).parse(messages);
+}

--- a/packages/database/src/queries/users/index.ts
+++ b/packages/database/src/queries/users/index.ts
@@ -3,3 +3,4 @@ export * from './users-to-organizations';
 export * from './find-user-by-email';
 export * from './get-user-organizations';
 export * from './user-queries';
+export * from './user-suggested-prompts';

--- a/packages/database/src/queries/users/user-queries.ts
+++ b/packages/database/src/queries/users/user-queries.ts
@@ -56,6 +56,7 @@ export async function findUserByEmailInOrganization(
         updatedAt: users.updatedAt,
         attributes: users.attributes,
         avatarUrl: users.avatarUrl,
+        suggestedPrompts: users.suggestedPrompts,
       })
       .from(users)
       .innerJoin(

--- a/packages/database/src/queries/users/user-suggested-prompts.ts
+++ b/packages/database/src/queries/users/user-suggested-prompts.ts
@@ -63,7 +63,7 @@ export async function updateUserSuggestedPrompts(
  */
 export async function getUserSuggestedPrompts(
   params: GetSuggestedPromptsInput
-): Promise<UserSuggestedPrompts | null> {
+): Promise<UserSuggestedPrompts> {
   try {
     const { userId } = GetSuggestedPromptsInputSchema.parse(params);
 
@@ -74,7 +74,12 @@ export async function getUserSuggestedPrompts(
       .limit(1);
 
     const user = result[0];
-    return user ? user.suggestedPrompts : null;
+
+    if (!user) {
+      throw new Error('User not found');
+    }
+
+    return user.suggestedPrompts;
   } catch (error) {
     if (error instanceof z.ZodError) {
       throw new Error(`Invalid input: ${error.errors.map((e) => e.message).join(', ')}`);

--- a/packages/database/src/queries/users/user-suggested-prompts.ts
+++ b/packages/database/src/queries/users/user-suggested-prompts.ts
@@ -1,0 +1,84 @@
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { db } from '../../connection';
+import { users } from '../../schema';
+import type { UserSuggestedPrompts } from '../../schema-types';
+
+// Input validation schemas
+const UpdateSuggestedPromptsInputSchema = z.object({
+  userId: z.string().uuid('User ID must be a valid UUID'),
+  suggestedPrompts: z.object({
+    report: z.array(z.string()),
+    dashboard: z.array(z.string()),
+    visualization: z.array(z.string()),
+    help: z.array(z.string()),
+  }),
+});
+
+const GetSuggestedPromptsInputSchema = z.object({
+  userId: z.string().uuid('User ID must be a valid UUID'),
+});
+
+type UpdateSuggestedPromptsInput = z.infer<typeof UpdateSuggestedPromptsInputSchema>;
+type GetSuggestedPromptsInput = z.infer<typeof GetSuggestedPromptsInputSchema>;
+
+/**
+ * Updates the suggested prompts for a user
+ */
+export async function updateUserSuggestedPrompts(
+  params: UpdateSuggestedPromptsInput
+): Promise<UserSuggestedPrompts> {
+  try {
+    const { userId, suggestedPrompts } = UpdateSuggestedPromptsInputSchema.parse(params);
+
+    const updatedPrompts: UserSuggestedPrompts = {
+      suggestedPrompts: suggestedPrompts,
+      updatedAt: new Date().toISOString(),
+    };
+
+    const result = await db
+      .update(users)
+      .set({
+        suggestedPrompts: updatedPrompts,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(users.id, userId))
+      .returning({ suggestedPrompts: users.suggestedPrompts });
+
+    if (!result.length || !result[0]) {
+      throw new Error('User not found');
+    }
+
+    return result[0].suggestedPrompts;
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new Error(`Invalid input: ${error.errors.map((e) => e.message).join(', ')}`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Gets the suggested prompts for a user
+ */
+export async function getUserSuggestedPrompts(
+  params: GetSuggestedPromptsInput
+): Promise<UserSuggestedPrompts | null> {
+  try {
+    const { userId } = GetSuggestedPromptsInputSchema.parse(params);
+
+    const result = await db
+      .select({ suggestedPrompts: users.suggestedPrompts })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1);
+
+    const user = result[0];
+    return user ? user.suggestedPrompts : null;
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new Error(`Invalid input: ${error.errors.map((e) => e.message).join(', ')}`);
+    }
+    throw error;
+  }
+}

--- a/packages/database/src/schema-types/index.ts
+++ b/packages/database/src/schema-types/index.ts
@@ -2,5 +2,8 @@
 export * from './organization';
 export * from './report-elements';
 
+// Export user-related types
+export * from './user';
+
 // Export enum types
 export * from './enums';

--- a/packages/database/src/schema-types/user.ts
+++ b/packages/database/src/schema-types/user.ts
@@ -1,0 +1,10 @@
+// User Suggested Prompts Types
+export type UserSuggestedPrompts = {
+  suggestedPrompts: {
+    report: string[];
+    dashboard: string[];
+    visualization: string[];
+    help: string[];
+  };
+  updatedAt: string; // ISO timestamp string to match the codebase pattern
+};

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -19,7 +19,7 @@ import {
   uuid,
   varchar,
 } from 'drizzle-orm/pg-core';
-import type { OrganizationColorPalettes } from './schema-types';
+import type { OrganizationColorPalettes, UserSuggestedPrompts } from './schema-types';
 
 export const assetPermissionRoleEnum = pgEnum('asset_permission_role_enum', [
   'owner',
@@ -857,6 +857,18 @@ export const users = pgTable(
       .notNull(),
     attributes: jsonb().default({}).notNull(),
     avatarUrl: text('avatar_url'),
+    suggestedPrompts: jsonb('suggested_prompts')
+      .$type<UserSuggestedPrompts>()
+      .default(sql`'{
+        "suggestedPrompts": {
+          "report": [],
+          "dashboard": [],
+          "visualization": [],
+          "help": []
+        },
+        "updatedAt": null
+      }'::jsonb`)
+      .notNull(),
   },
   (table) => [unique('users_email_key').on(table.email)]
 );

--- a/packages/server-shared/src/user/index.ts
+++ b/packages/server-shared/src/user/index.ts
@@ -5,3 +5,4 @@ export * from './roles.types';
 export * from '../teams/teams.types';
 export * from './sharing-setting.types';
 export * from './favorites.types';
+export * from './suggested-prompts.types';

--- a/packages/server-shared/src/user/suggested-prompts.types.ts
+++ b/packages/server-shared/src/user/suggested-prompts.types.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+// Core suggested prompts schema that matches the database schema
+export const SuggestedPromptsSchema = z.object({
+  report: z.array(z.string()),
+  dashboard: z.array(z.string()),
+  visualization: z.array(z.string()),
+  help: z.array(z.string()),
+});
+
+export type SuggestedPrompts = z.infer<typeof SuggestedPromptsSchema>;
+
+// Request schemas
+export const GenerateSuggestedPromptsRequestSchema = z.object({
+  userId: z.string().uuid().optional(), // Optional for admin use - defaults to authenticated user
+});
+
+export const GetSuggestedPromptsRequestSchema = z.object({
+  userId: z.string().uuid().optional(), // Optional for admin use - defaults to authenticated user
+});
+
+// Response schemas
+export const SuggestedPromptsResponseSchema = z.object({
+  suggestedPrompts: SuggestedPromptsSchema,
+  updatedAt: z.string(), // ISO timestamp string
+});
+
+// Inferred types
+export type GenerateSuggestedPromptsRequest = z.infer<typeof GenerateSuggestedPromptsRequestSchema>;
+export type GetSuggestedPromptsRequest = z.infer<typeof GetSuggestedPromptsRequestSchema>;
+export type SuggestedPromptsResponse = z.infer<typeof SuggestedPromptsResponseSchema>;

--- a/packages/server-shared/src/user/suggested-prompts.types.ts
+++ b/packages/server-shared/src/user/suggested-prompts.types.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 
-// Core suggested prompts schema that matches the database schema
 export const SuggestedPromptsSchema = z.object({
   report: z.array(z.string()),
   dashboard: z.array(z.string()),
@@ -25,7 +24,6 @@ export const SuggestedPromptsResponseSchema = z.object({
   updatedAt: z.string(), // ISO timestamp string
 });
 
-// Inferred types
 export type GenerateSuggestedPromptsRequest = z.infer<typeof GenerateSuggestedPromptsRequestSchema>;
 export type GetSuggestedPromptsRequest = z.infer<typeof GetSuggestedPromptsRequestSchema>;
 export type SuggestedPromptsResponse = z.infer<typeof SuggestedPromptsResponseSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -938,6 +938,9 @@ importers:
       '@ai-sdk/gateway':
         specifier: ^1.0.18
         version: 1.0.18(zod@3.25.76)
+      '@ai-sdk/openai':
+        specifier: 2.0.0-beta.16
+        version: 2.0.0-beta.16(zod@3.25.76)
       '@ai-sdk/provider':
         specifier: ^2.0.0
         version: 2.0.0

--- a/test_gpg.md
+++ b/test_gpg.md
@@ -1,0 +1,1 @@
+# Test file for GPG signing


### PR DESCRIPTION

This PR implements a complete backend system for generating personalized suggested prompts for users on the home page. The feature adds a suggestedPrompts JSONB column to the users table, creates GET/POST API endpoints at /api/v2/users/{id}/suggested-prompts for retrieving and generating prompts, and integrates an AI task using GPT-5 Nano that analyzes the user's chat history and available database schemas to produce contextually relevant suggestions across four categories (reports, dashboards, visualizations, help). The implementation includes comprehensive TypeScript types, proper authentication/authorization, concurrent data fetching for performance, robust error handling with fallbacks, and maintains full type safety from database to API responses while ensuring all builds pass and linting compliance across the monorepo.